### PR TITLE
fix: LAST_INSERT_ID() breaks on some MySQL compliant databases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - "postgresql"
 
 addons:
-  "postgresql": "9.5"
+  "postgresql": "10"
 
 after_success:
   - npm run coveralls

--- a/lib/bone.js
+++ b/lib/bone.js
@@ -310,7 +310,8 @@ class Bone {
     // - http://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_last-insert-id
     const spell = new Spell(Model, async spell => {
       const result = await Model.query(spell)
-      this[primaryKey] = result.insertId
+      // LAST_INSERT_ID() breaks on TDDL
+      if (this[primaryKey] == null) this[primaryKey] = result.insertId
       this.syncRaw()
       return result.affectedRows
     })

--- a/package.json
+++ b/package.json
@@ -32,21 +32,21 @@
   },
   "dependencies": {
     "debug": "^3.1.0",
-    "deep-equal": "^1.0.1",
+    "deep-equal": "^1.1.1",
     "pluralize": "^7.0.0",
     "sqlstring": "^2.3.0"
   },
   "devDependencies": {
     "@cara/minami": "^1.2.3",
     "babel-eslint": "^10.0.3",
-    "coveralls": "^3.0.2",
+    "coveralls": "^3.0.9",
     "eslint": "^6.7.2",
     "expect.js": "^0.3.1",
-    "jsdoc": "^3.5.5",
+    "jsdoc": "^3.6.3",
     "mocha": "^5.2.0",
-    "mysql": "^2.15.0",
-    "mysql2": "^1.5.1",
+    "mysql": "^2.17.1",
+    "mysql2": "^1.7.0",
     "nyc": "^13.1.0",
-    "pg": "^7.6.0"
+    "pg": "^7.14.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
   },
   "devDependencies": {
     "@cara/minami": "^1.2.3",
+    "babel-eslint": "^10.0.3",
     "coveralls": "^3.0.2",
+    "eslint": "^6.7.2",
     "expect.js": "^0.3.1",
     "jsdoc": "^3.5.5",
     "mocha": "^5.2.0",

--- a/test/suite/basics.js
+++ b/test/suite/basics.js
@@ -525,6 +525,14 @@ describe('=> Update', function() {
     // INSERT ... UPDATE returns 2 if the UPDATE branch were chosen in MySQL database
     assert.equal(await post.upsert(), Post.pool.Leoric_type === 'mysql' ? 2 : 1)
   })
+
+  it('bone.upsert() should not override existing primary key', async function() {
+    const { id } = await Post.create({ title: 'New Post' })
+    const post = new Post({ id, title: 'New Post 2' })
+    await post.upsert()
+    assert.equal(post.id, id)
+    assert.equal(post.title, 'New Post 2')
+  })
 })
 
 describe('=> Remove', function() {

--- a/test/suite/querying.js
+++ b/test/suite/querying.js
@@ -414,7 +414,7 @@ describe('=> Group / Join / Subqueries', function() {
       Post.create({ id: 1, title: 'New Post' }),
       Post.create({ id: 2, title: 'Archbishop Lazarus' }),
       Post.create({ id: 3, title: 'Archangel Tyrael' }),
-      Post.create({ id: 4, title: 'New Post' })
+      Post.create({ id: 4, title: 'New Post 2' })
     ])
 
     await Promise.all([


### PR DESCRIPTION
even with `UPDATE id = LAST_INSERT_ID(id)` hack https://stackoverflow.com/questions/778534/mysql-on-duplicate-key-last-insert-id

cc @chenhui5416 