### PR TITLE
fix: findOne(null|undefined) shall return null

### DIFF
--- a/lib/adapters/sequelize.js
+++ b/lib/adapters/sequelize.js
@@ -142,11 +142,15 @@ module.exports = Bone => {
       return instance;
     }
 
-    static findOne(options = {}) {
-      if (options != null && typeof options !== 'object') {
-        // findOne(id)
-        return super.findOne(options);
-      }
+    static findOne(options) {
+      // findOne(null)
+      if (arguments.length > 0 && options == null) return null;
+
+      // findOne(id)
+      if (typeof options !== 'object') return super.findOne(options);
+
+      // findOne({ where })
+      // findOne()
       return this.findAll({ ...options, limit: 1 }).later(result => result[0]);
     }
 

--- a/lib/bone.js
+++ b/lib/bone.js
@@ -731,6 +731,8 @@ class Bone {
   static find(conditions, ...values) {
     const spell = new Spell(this);
     const conditionsType = typeof conditions;
+    // find(1)
+    // find([ 1, 2, 3 ])
     if (Array.isArray(conditions) || conditionsType == 'number') {
       spell.$where({ [this.primaryKey]: conditions });
     }

--- a/test/unit/adapters/test.sequelize.js
+++ b/test/unit/adapters/test.sequelize.js
@@ -222,6 +222,20 @@ describe('=> Sequelize adapter', () => {
     assert.equal(post2.title, 'Leah');
   });
 
+  it('Model.findOne()', async () => {
+    const { id } = await Post.create({ title: 'Leah' });
+
+    const post = await Post.findOne();
+    assert.equal(post.title, 'Leah');
+
+    // if passed value, take the value as primary key
+    assert.deepEqual((await Post.findOne(id)).toJSON(), post.toJSON());
+
+    // if passed null or undefined, return null
+    assert.equal(await Post.findOne(null), null);
+    assert.equal(await Post.findOne(undefined), null);
+  });
+
   it('Model.increment()', async () => {
     const isbn = 9787550616950;
     const book = await Book.create({ isbn, name: 'Book of Cain', price: 10 });


### PR DESCRIPTION
... where as findOne() still returns an arbitrary row