### PR TITLE
fix: instance[key] should not change after updating failed

### DIFF
--- a/lib/bone.js
+++ b/lib/bone.js
@@ -305,7 +305,7 @@ class Bone {
     }
     const result = {};
     for (const attrKey of Object.keys(this.constructor.attributes)) {
-      if (this.rawUnset.has(name)) continue;
+      if (this.rawUnset.has(attrKey)) continue;
       const value = this.attribute(attrKey);
       const valueWas = this.attributeWas(attrKey);
 
@@ -492,12 +492,12 @@ class Bone {
       }
     } else {
       for (const name in opts) {
-        const originValue = this[name];
+        const originValue = this.attribute(name);
         // exec custom setters in case it exist
         this[name] = opts[name];
         changes[name] = this.attribute(name);
         // revert value in case update failed
-        this[name] = originValue;
+        this.attribute(name, originValue);
       }
     }
 
@@ -518,9 +518,9 @@ class Bone {
     }
     const spell = new Spell(Model).$where(where).$update(changes);
     return spell.later(result => {
-      // sync changes
+      // sync changes (changes has been formatted by custom setters, use this.attribute(name, value) directly)
       for (const key in changes) {
-        this[key] = changes[key];
+        this.attribute(key, changes[key]);
       }
       this.syncRaw(changes);
       return result.affectedRows;

--- a/lib/bone.js
+++ b/lib/bone.js
@@ -164,7 +164,7 @@ class Bone {
     const changes = this.changes();
     let changedValue = {};
     for (const key in changes) {
-      if (changes[key].length && changes[key].length === 2) {
+      if (changes[key].length === 2) {
         changedValue[key] = changes[key][1];
       }
     }

--- a/lib/bone.js
+++ b/lib/bone.js
@@ -475,9 +475,12 @@ class Bone {
       }
     } else {
       for (const name in opts) {
+        const originValue = this[name];
         // exec custom setters in case it exist
         this[name] = opts[name];
         changes[name] = this.attribute(name);
+        // revert value in case update failed
+        this[name] = originValue;
       }
     }
 
@@ -498,6 +501,10 @@ class Bone {
     }
     const spell = new Spell(Model).$where(where).$update(changes);
     return spell.later(result => {
+      // sync changes
+      for (const key in changes) {
+        this[key] = changes[key];
+      }
       this.syncRaw(changes);
       return result.affectedRows;
     });

--- a/lib/bone.js
+++ b/lib/bone.js
@@ -160,10 +160,26 @@ class Bone {
    */
   _validateAttributes(values = {}) {
     const { attributes } = this.constructor;
-    Object.keys(this.raw).map((valueKey) => {
+    // check changed values
+    const changes = this.changes();
+    let changedValue = {};
+    for (const key in changes) {
+      if (changes[key].length && changes[key].length === 2) {
+        changedValue[key] = changes[key][1];
+      }
+    }
+
+    // merge all changed values
+    changedValue = {
+      ...changedValue,
+      ...values,
+    };
+
+    Object.keys(changedValue).map((valueKey) => {
       const attribute = attributes[valueKey];
+      if (!attribute) return;
       const { validate = {}, name, allowNull, defaultValue } = attribute;
-      const value = values[name] != null? values[name]: this.raw[name];
+      const value = changedValue[valueKey];
       if (value == null && defaultValue == null) {
         if (allowNull === false) throw new LeoricValidateError('notNull', name);
         if ((allowNull === true || allowNull === undefined) && validate.notNull === undefined ) return;
@@ -292,6 +308,7 @@ class Bone {
       if (this.rawUnset.has(name)) continue;
       const value = this.attribute(attrKey);
       const valueWas = this.attributeWas(attrKey);
+
       if (!util.isDeepStrictEqual(value, valueWas)) {
         result[attrKey] = [ valueWas, value ];
       }

--- a/lib/bone.js
+++ b/lib/bone.js
@@ -162,24 +162,21 @@ class Bone {
     const { attributes } = this.constructor;
     // check changed values
     const changes = this.changes();
-    let changedValue = {};
+    let changedValues = {};
     for (const key in changes) {
       if (changes[key].length === 2) {
-        changedValue[key] = changes[key][1];
+        changedValues[key] = changes[key][1];
       }
     }
 
     // merge all changed values
-    changedValue = {
-      ...changedValue,
-      ...values,
-    };
+    changedValues = Object.assign(changedValues, values);
 
-    Object.keys(changedValue).map((valueKey) => {
+    for (const valueKey in changedValues) {
       const attribute = attributes[valueKey];
-      if (!attribute) return;
+      if (!attribute) continue;
       const { validate = {}, name, allowNull, defaultValue } = attribute;
-      const value = changedValue[valueKey];
+      const value = changedValues[valueKey];
       if (value == null && defaultValue == null) {
         if (allowNull === false) throw new LeoricValidateError('notNull', name);
         if ((allowNull === true || allowNull === undefined) && validate.notNull === undefined ) return;
@@ -188,7 +185,7 @@ class Bone {
       for (const key in validate) {
         if (validate.hasOwnProperty(key)) executeValidator(this, key, attribute, value);
       }
-    });
+    }
   }
 
   /**
@@ -200,7 +197,7 @@ class Bone {
    */
   static _validateAttributes(values = {}) {
     const { attributes } = this;
-    Object.keys(values).map((valueKey) => {
+    for (const valueKey in values) {
       const attribute = attributes[valueKey];
       if (!attribute) throw new Error(`${this.name} has no attribute "${valueKey}"`);
       const { validate = {}, name, allowNull, defaultValue } = attribute;
@@ -213,7 +210,7 @@ class Bone {
       for (const key in validate) {
         if (validate.hasOwnProperty(key)) executeValidator(this, key, attribute, value);
       }
-    });
+    }
   }
 
   /**

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -71,7 +71,7 @@ function executeValidator(ctx, name, attribute, setValue) {
     // custom validator
     try {
       // Make sure this[name] callable and not return undefined or previous value (instance only) during validator executing while updating or saving
-      if (ctx.raw && !ctx.raw[field]) {
+      if (ctx.raw) {
         needToRevert = true;
         ctx.raw[field] = value;
       }

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -49,6 +49,9 @@ const validators = {
   is(str, pattern, modifiers) {
     return this.regex(str, pattern, modifiers);
   },
+  notEmpty(str) {
+    return !str.match(/^[\s\t\r\n]*$/);
+  },
 };
 
 /**
@@ -64,19 +67,23 @@ function executeValidator(ctx, name, attribute, setValue) {
 
   const value = setValue != null? setValue : defaultValue;
   if (typeof validateArgs === 'function') {
+    let needToRevert = false;
     // custom validator
     try {
-      // Make sure this[name] callable and not return undefined or previous value (instance only) during validator executing
-      if (ctx.raw) ctx.raw[field] = value;
+      // Make sure this[name] callable and not return undefined or previous value (instance only) during validator executing while updating or saving
+      if (ctx.raw && !ctx.raw[field]) {
+        needToRevert = true;
+        ctx.raw[field] = value;
+      }
       const execRes = validateArgs.call(ctx, value);
       if (execRes === false) throw new LeoricValidateError(name, field);
     } catch (err) {
       // revert value (instance only)
-      if (ctx.raw) ctx.raw[field] = ctx.rawSaved[field];
+      if (ctx.raw && needToRevert) ctx.raw[field] = ctx.rawSaved[field];
       throw err;
     }
     // revert value (instance only)
-    if (ctx.raw) ctx.raw[field] = ctx.rawSaved[field];
+    if (ctx.raw && needToRevert) ctx.raw[field] = ctx.rawSaved[field];
   } else {
     const validator = validators[name];
     if (typeof validator !== 'function') throw new LeoricValidateError(`Invalid validator function: ${name}`);

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -68,22 +68,24 @@ function executeValidator(ctx, name, attribute, setValue) {
   const value = setValue != null? setValue : defaultValue;
   if (typeof validateArgs === 'function') {
     let needToRevert = false;
+    let originValue;
     // custom validator
     try {
       // Make sure this[name] callable and not return undefined or previous value (instance only) during validator executing while updating or saving
       if (ctx.raw) {
         needToRevert = true;
+        originValue = ctx.raw[field];
         ctx.raw[field] = value;
       }
       const execRes = validateArgs.call(ctx, value);
       if (execRes === false) throw new LeoricValidateError(name, field);
     } catch (err) {
       // revert value (instance only)
-      if (ctx.raw && needToRevert) ctx.raw[field] = ctx.rawSaved[field];
+      if (ctx.raw && needToRevert) ctx.raw[field] = originValue;
       throw err;
     }
     // revert value (instance only)
-    if (ctx.raw && needToRevert) ctx.raw[field] = ctx.rawSaved[field];
+    if (ctx.raw && needToRevert) ctx.raw[field] = originValue;
   } else {
     const validator = validators[name];
     if (typeof validator !== 'function') throw new LeoricValidateError(`Invalid validator function: ${name}`);

--- a/test/integration/suite/basics.test.js
+++ b/test/integration/suite/basics.test.js
@@ -140,12 +140,12 @@ describe('=> Attributes', function() {
     post.extra = 'hello2';
     await post.save();
     // should return updated attributes' name after updating
-    assert.deepEqual(post.previousChanged(), ['extra']);
+    assert.deepEqual(post.previousChanged().sort(), ['extra', 'updatedAt']);
     post.title = 'monster hunter';
     post.extra = 'hello3';
     await post.save();
     // should return updated attributes' name after updating
-    assert.deepEqual(post.previousChanged().sort(), [ 'extra', 'title' ]);
+    assert.deepEqual(post.previousChanged().sort(), [ 'extra', 'title', 'updatedAt' ]);
   });
 
   it('Bone.previousChanges(key): raw VS rawPrevious', async function () {
@@ -164,8 +164,9 @@ describe('=> Attributes', function() {
     await post.save();
     assert.deepEqual(post.previousChanges(), {});
     post.title = 'MHW';
+    const prevUpdatedAt = post.updatedAt;
     await post.save();
-    assert.deepEqual(post.previousChanges(), { title: [ 'Untitled', 'MHW' ] });
+    assert.deepEqual(post.previousChanges(), { title: [ 'Untitled', 'MHW' ], updatedAt: [ prevUpdatedAt, post.updatedAt ] });
   });
 
   it('Bone.changes(key): raw VS rawSaved', async function () {
@@ -306,6 +307,13 @@ describe('=> Accessors', function() {
     expect(user.status).to.eql(1);
     expect(user.raw.status).to.equal(-1);
     await user.update({ status: 2 });
+    //set status(value = 0) {
+    //   this.attribute('status', value - 2);
+    // },
+    //  get status() {
+    //   const status = this.attribute('status');
+    //   return status + 2;
+    // }
     expect(user.status).to.eql(2);
     expect(user.raw.status).to.equal(0);
   });

--- a/test/integration/suite/basics.test.js
+++ b/test/integration/suite/basics.test.js
@@ -10,6 +10,10 @@ const Post = require('../../models/post');
 const TagMap = require('../../models/tagMap');
 const User = require('../../models/user');
 
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 describe('=> Attributes', function() {
   beforeEach(async function() {
     await Post.remove({}, true);
@@ -138,11 +142,13 @@ describe('=> Attributes', function() {
     // should return false after first persist
     assert.equal(post.previousChanged(), false);
     post.extra = 'hello2';
+    await sleep(10);
     await post.save();
     // should return updated attributes' name after updating
     assert.deepEqual(post.previousChanged().sort(), ['extra', 'updatedAt']);
     post.title = 'monster hunter';
     post.extra = 'hello3';
+    await sleep(10);
     await post.save();
     // should return updated attributes' name after updating
     assert.deepEqual(post.previousChanged().sort(), [ 'extra', 'title', 'updatedAt' ]);

--- a/test/integration/suite/basics.test.js
+++ b/test/integration/suite/basics.test.js
@@ -171,6 +171,7 @@ describe('=> Attributes', function() {
     assert.deepEqual(post.previousChanges(), {});
     post.title = 'MHW';
     const prevUpdatedAt = post.updatedAt;
+    await sleep(10);
     await post.save();
     assert.deepEqual(post.previousChanges(), { title: [ 'Untitled', 'MHW' ], updatedAt: [ prevUpdatedAt, post.updatedAt ] });
   });

--- a/test/unit/adapters/sequelize.test.js
+++ b/test/unit/adapters/sequelize.test.js
@@ -947,6 +947,25 @@ describe('validator should work', () => {
         fingerprint: 'aaa',
       }, { validate: false });
       assert(user);
+      assert(user.email);
+      assert(user.nickname);
+      assert(user.fingerprint);
+    });
+
+
+    it('build validate should work', async () => {
+      const user = User.build({
+        email: 'a@e.com',
+        nickname: 'sss',
+      });
+      assert(user);
+      assert(user.email);
+      assert(user.nickname);
+
+      await user.save();
+      assert(user.id);
+      assert(user.email);
+      assert(user.nickname);
     });
   });
 

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -108,6 +108,8 @@ describe('validator', () => {
         nickname: 'sss'
       });
       assert(user);
+      assert(user.email);
+      assert(user.nickname);
     });
 
     it('notNull', async () => {

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -113,8 +113,10 @@ describe('validator', () => {
     it('notNull', async () => {
       const user = new User({
         email: 'a@e.com',
-        nickname: null,
+        nickname: 'sss',
       });
+      await user.save();
+      user.nickname = null;
       await assert.rejects(async () => {
         await user.save();
       }, /Validation notNull on nickname failed/);

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -233,11 +233,13 @@ describe('validator', () => {
       const user = new User({
         email: 'a@e.com',
         nickname: 'sss',
+        fingerprint: 'finger111'
       });
       await user.create();
       await assert.rejects(async () => {
         await User.update({ email: 'a@e.com', }, { fingerprint: 'aaa' });
       }, /Validation contains on fingerprint failed/);
+      assert.equal(user.fingerprint, 'finger111');
     });
 
     it('update(class) skip validate should work', async () => {
@@ -255,11 +257,14 @@ describe('validator', () => {
       const user = new User({
         email: 'a@e.com',
         nickname: 'sss',
+        fingerprint: 'finger111'
       });
       await user.create();
       await assert.rejects(async () => {
         await user.update({ fingerprint: 'aaa' });
       }, /Validation contains on fingerprint failed/);
+      // fingerprint should not be assigned to 'aaa'
+      assert.equal(user.fingerprint, 'finger111');
     });
 
     it('update(instance) skip validate should work', async () => {


### PR DESCRIPTION
fix: instance[key] should not change after updating failed
eg.
```js
const user = new User({
    email: 'a@e.com',
    nickname: 'sss',
    fingerprint: 'finger111'
});
try {
    // assume it will be failed
    await user.update({ fingerprint: 'aaa' });
} catch (err) {}

user.fingerprint // should be 'finger111', not 'aaa'


```