### PR TITLE
Fix/sequelize mode destroy hooks

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,7 +32,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/lib/adapters/sequelize.js
+++ b/lib/adapters/sequelize.js
@@ -139,22 +139,22 @@ module.exports = Bone => {
     //   throw new Error('unimplemented');
     // }
 
-    static async destroy(options = {}, runOpt = {}) {
+    static async destroy(options = {}) {
       const { where, individualHooks } = options;
       if (individualHooks) {
         const instances = await this.find(where);
         if (instances.length) {
-          return await Promise.all(instances.map(async (instance) => await instance.destroy(options, runOpt)));
+          return await Promise.all(instances.map((instance) => instance.destroy(options)));
         }
       } else {
-        return await this.bulkDestroy(options, runOpt);
+        return await this.bulkDestroy(options);
       }
     }
 
     // proxy to class.destroy({ individualHooks=false }) see https://github.com/sequelize/sequelize/blob/4063c2ab627ad57919d5b45cc7755f077a69fa5e/lib/model.js#L2895  before(after)BulkDestroy
     static async bulkDestroy(options = {}) {
-      const { where, force } = options;
-      return await this.remove(where || {}, force);
+      const { where, force, hooks } = options;
+      return await this.remove(where || {}, force, { hooks });
     }
 
     // EXISTS
@@ -387,8 +387,8 @@ module.exports = Bone => {
       });
     }
 
-    async destroy(options = {}, runOpt = {}) {
-      return await this.remove(options.force, { ...runOpt, hooks: false });
+    async destroy(options = {}) {
+      return await this.remove(options.force, { ...options, hooks: false });
     }
 
     equals() {

--- a/lib/adapters/sequelize.js
+++ b/lib/adapters/sequelize.js
@@ -139,7 +139,20 @@ module.exports = Bone => {
     //   throw new Error('unimplemented');
     // }
 
-    static async destroy(options = {}) {
+    static async destroy(options = {}, runOpt = {}) {
+      const { where, individualHooks } = options;
+      if (individualHooks) {
+        const instances = await this.find(where);
+        if (instances.length) {
+          return await Promise.all(instances.map(async (instance) => await instance.destroy(options, runOpt)));
+        }
+      } else {
+        return await this.bulkDestroy(options, runOpt);
+      }
+    }
+
+    // proxy to class.destroy({ individualHooks=false }) see https://github.com/sequelize/sequelize/blob/4063c2ab627ad57919d5b45cc7755f077a69fa5e/lib/model.js#L2895  before(after)BulkDestroy
+    static async bulkDestroy(options = {}) {
       const { where, force } = options;
       return await this.remove(where || {}, force);
     }
@@ -374,7 +387,7 @@ module.exports = Bone => {
       });
     }
 
-    async destroy(options = {}, runOpt) {
+    async destroy(options = {}, runOpt = {}) {
       return await this.remove(options.force, { ...runOpt, hooks: false });
     }
 

--- a/lib/bone.js
+++ b/lib/bone.js
@@ -573,15 +573,15 @@ class Bone {
    * @returns
    * @memberof Bone
    */
-  update(opts) {
-    return this._update(opts);
+  update(opts, queryOpts = {}) {
+    return this._update(opts, queryOpts);
   }
   /**
    * Persist changes on current instance back to database with `UPDATE`.
    * @private
    * @return {number}
    */
-  update(opts, queryOpts = {}) {
+  _update(opts, queryOpts = {}) {
     const changes = opts != null && typeof opts === 'object' ? opts : {};
     const Model = this.constructor;
     const { attributes, primaryKey, shardingKey } = Model;

--- a/lib/setup_hooks.js
+++ b/lib/setup_hooks.js
@@ -61,14 +61,14 @@ function formatArgs(isInstance, fnName, args, target) {
     case 'destroy': {
       // instance.destroy(options)
       argsRes = [ target, ...args ];
-      opts = args[1];
+      opts = args[0];
       if (opts && opts.hooks === false) useHooks = false;
       break;
     }
     // sequelize mode only
     case 'bulkDestroy': {
       argsRes = args; // class.destroy
-      opts = args[1];
+      opts = args[0];
       if (opts && opts.hooks === false) useHooks = false;
       break;
     }

--- a/lib/setup_hooks.js
+++ b/lib/setup_hooks.js
@@ -57,10 +57,17 @@ function formatArgs(isInstance, fnName, args, target) {
       if (opts && opts.hooks === false) useHooks = false;
       break;
     }
+    // sequelize mode instance only
     case 'destroy': {
       // instance.destroy(options)
-      if (isInstance) argsRes = [ target, ...args ];
-      else argsRes = args; // class.destroy
+      argsRes = [ target, ...args ];
+      opts = args[1];
+      if (opts && opts.hooks === false) useHooks = false;
+      break;
+    }
+    // sequelize mode only
+    case 'bulkDestroy': {
+      argsRes = args; // class.destroy
       opts = args[1];
       if (opts && opts.hooks === false) useHooks = false;
       break;
@@ -85,11 +92,11 @@ function getFnType(hookName) {
   const res = hookName.split(/([A-Z]\w+$)/);
   return {
     type: res[0],
-    method: res[1].toLowerCase(),
+    method: res[1].replace(res[1][0], res[1][0].toLowerCase()),
   };
 }
 
-const hookableMethods = [ 'update', 'create', 'destroy', 'upsert', 'remove', 'save' ]; // save equals to update|create|upsert
+const hookableMethods = [ 'update', 'create', 'destroy', 'upsert', 'remove', 'save', 'bulkDestroy' ]; // save equals to update|create|upsert, bulkDestroy equals to class.destroy
 const hookType = {
   BEFORE: 'before',
   AFTER: 'after',
@@ -118,7 +125,7 @@ function addHook(target, hookName, func) {
 
     // class static method
     // static create proxy to instance.create
-    if (method === 'create') return;
+    if (method === 'create' || method === 'destroy') return;
     const classOriginMethod = target[method];
     target[method] = async function() {
       const { useHooks, args } = formatArgs(false, method, arguments, this);

--- a/test/integration/suite/querying.test.js
+++ b/test/integration/suite/querying.test.js
@@ -571,7 +571,8 @@ describe('=> Group / Join / Subqueries', function() {
 });
 
 describe('=> Calculations', function() {
-  before(async function() {
+  beforeEach(async function() {
+    await Book.remove({}, true);
     await Promise.all([
       Book.create({ isbn: 9780596006624, name: 'Hackers and Painters', price: 22.95 }),
       Book.create({ isbn: 9780881792065, name: 'The Elements of Typographic Style', price: 29.95 }),

--- a/test/start.sh
+++ b/test/start.sh
@@ -14,7 +14,7 @@ function run {
 function unit {
   # recursive glob nor available in bash 3
   # - https://unix.stackexchange.com/questions/49913/recursive-glob
-  for file in $(ls test/unit/{,drivers/,drivers/*/}*.test.js); do
+  for file in $(ls test/unit/{,drivers/,drivers/*/,adapters/,adapters/*/}*.test.js); do
     run ${file};
   done
 }

--- a/test/unit/adapters/sequelize.test.js
+++ b/test/unit/adapters/sequelize.test.js
@@ -671,7 +671,7 @@ describe('=> Sequelize adapter', () => {
     post.title = 'Hello there';
     assert.equal(post.changed('title'), true);
     await post.update();
-    assert.equal(post.changed('title'), true);
+    assert.equal(post.changed('title'), false);
     assert.equal(post.attributeChanged('title'), false);
     assert.equal(post.previous('title'), 'By three they come');
   });

--- a/test/unit/hooks.test.js
+++ b/test/unit/hooks.test.js
@@ -378,6 +378,12 @@ describe('hooks', function() {
             obj.status = 11;
           }
           afterProbe = 'after';
+        },
+        beforeBulkDestroy() {
+          beforeProbe = 'before';
+        },
+        afterBulkDestroy() {
+          afterProbe = 'after';
         }
       }
     });
@@ -604,6 +610,42 @@ describe('hooks', function() {
         assert.equal(afterProbe, null);
       });
 
+      it('bulkDestroy hooks', async () => {
+        let beforeProbe;
+        User.addHook('beforeBulkDestroy', 'test', (obj) => {
+          beforeProbe = 'before';
+        });
+        let afterProbe;
+        User.addHook('afterBulkDestroy', 'test', (obj) => {
+          afterProbe = 'after';
+        });
+
+        await User.create({ nickname: 'tim', email: 'h@h.com' ,meta: { foo: 1, bar: 'baz'}, status: 1 }, { hooks: false });
+        await User.destroy({
+          where: {
+            nickname: 'tim'
+          }
+        });
+
+        assert.equal(beforeProbe, 'before');
+        assert.equal(afterProbe, 'after');
+
+        await User.create({ nickname: 'tim1', email: 'h1@h.com' ,meta: { foo: 1, bar: 'baz'}, status: 1 }, { hooks: false });
+
+        // skip hook should work
+        beforeProbe = null;
+        afterProbe = null;
+
+        await User.destroy({
+          where: {
+            nickname: 'tim1'
+          }
+        }, { hooks: false });
+
+        assert.equal(beforeProbe, null);
+        assert.equal(afterProbe, null);
+      });
+
       it('destroy hooks', async () => {
         let beforeProbe;
         User.addHook('beforeDestroy', 'test', (obj) => {
@@ -614,12 +656,8 @@ describe('hooks', function() {
           afterProbe = 'after';
         });
 
-        await User.create({ nickname: 'tim', email: 'h@h.com' ,meta: { foo: 1, bar: 'baz'}, status: 1 }, { hooks: false });
-        await User.destroy({
-          where: {
-            nickname: 'tim'
-          }
-        });
+        const user = await User.create({ nickname: 'tim', email: 'h@h.com' ,meta: { foo: 1, bar: 'baz'}, status: 1 }, { hooks: false });
+        await user.destroy();
         assert.equal(beforeProbe, 'before');
         assert.equal(afterProbe, 'after');
 

--- a/test/unit/hooks.test.js
+++ b/test/unit/hooks.test.js
@@ -422,7 +422,7 @@ describe('hooks', function() {
       const user = await User.create({ nickname: 'tim', email: 'h@h.com' ,meta: { foo: 1, bar: 'baz'}, status: 1 });
       assert(user.email === 'h@h.com');
       assert.equal(user.nickname, 'tim');
-      await user.destroy(true, { hooks: false });
+      await user.destroy({ force: true, hooks: false });
       assert.equal(user.email, 'h@h.com');
       assert.equal(user.status, 1);
       assert(!beforeProbe);
@@ -434,7 +434,9 @@ describe('hooks', function() {
       assert(user.email === 'h@h.com');
       assert.equal(user.nickname, 'tim');
       await User.destroy({
-        id: user.id,
+        where: {
+          id: user.id,
+        }
       });
       const updatedUser = await User.findOne(user.id);
       assert(!updatedUser);
@@ -447,8 +449,11 @@ describe('hooks', function() {
       assert(user.email === 'h@h.com');
       assert.equal(user.nickname, 'tim');
       await User.destroy({
-        id: user.id,
-      }, { hooks: false });
+        where: {
+          id: user.id,
+        },
+        hooks: false,
+      });
       const updatedUser = await User.findOne(user.id);
       assert(!updatedUser);
       assert(!beforeProbe);
@@ -639,8 +644,9 @@ describe('hooks', function() {
         await User.destroy({
           where: {
             nickname: 'tim1'
-          }
-        }, { hooks: false });
+          },
+          hooks: false,
+        });
 
         assert.equal(beforeProbe, null);
         assert.equal(afterProbe, null);


### PR DESCRIPTION
see https://github.com/sequelize/sequelize/blob/4063c2ab627ad57919d5b45cc7755f077a69fa5e/lib/model.js#L2895  before(after)BulkDestroy

destroy with `individualHooks=true` need to put instance in context during hooks executing