### PR TITLE
feat: support multiple order rules in one single string or one-dimensional array

### DIFF
--- a/lib/adapters/sequelize.js
+++ b/lib/adapters/sequelize.js
@@ -12,16 +12,7 @@ function translateOptions(spell, options) {
   }
   if (where) spell.$where(where);
   if (group) spell.$group(group);
-  if (order) {
-    if (typeof order === 'string') {
-      spell.$order(order);
-    } else if (Array.isArray(order)) {
-      // [[ 'createdAt', 'desc' ]]
-      for (const entry of order) {
-        if (Array.isArray(entry)) spell.$order(entry[0], entry[1]);
-      }
-    }
-  }
+  if (order) spell.$order(order);
   if (limit) spell.$limit(limit);
   if (offset) spell.$offset(offset);
 }

--- a/lib/drivers/abstract/spellbook.js
+++ b/lib/drivers/abstract/spellbook.js
@@ -26,10 +26,11 @@ function findModel(spell, qualifiers) {
  * @param {Object[]} orders
  */
 function formatOrders(spell, orders) {
-  return orders.map(([token, order]) => {
+  const rs = orders.map(([token, order]) => {
     const column = formatColumn(spell, token);
     return order == 'desc' ? `${column} DESC` : column;
   });
+  return rs;
 }
 
 /**
@@ -109,8 +110,11 @@ function formatLiteral(spell, ast) {
 
   if (value == null) {
     return 'NULL';
+  } else if (Array.isArray(value)) {
+    if (value.length) return `(${value.map(() => '?').join(', ')})`;
+    return '';
   } else {
-    return Array.isArray(value) ? `(${value.map(() => '?').join(', ')})` : '?';
+    return '?';
   }
 }
 
@@ -183,7 +187,7 @@ function formatOpExpr(spell, ast) {
   }
   // IN (1, 2, 3)
   // IN (SELECT user_id FROM group_users)
-  else if ((args[1].type == 'literal' && Array.isArray(args[1].value)) || args[1].type == 'subquery') {
+  else if ((args[1].type == 'literal' && Array.isArray(args[1].value) && args[1].value.length) || args[1].type == 'subquery') {
     let op = name;
     if (name == '=') {
       op = 'in';
@@ -277,7 +281,7 @@ function formatOpExpr(spell, ast) {
       throw new Error(`Invalid operator ${innerOp} against ${args[1].value}`);
     }
 
-  } else {
+  } else if (params[1] !== '') {
     return `${params[0]} ${name.toUpperCase()} ${params[1]}`;
   }
 }
@@ -560,6 +564,8 @@ function formatConditions(spell, conditions) {
         ? `(${formatExpr(spell, condition)})`
         : formatExpr(spell, condition);
     })
+    // filter empty condition
+    .filter((condition) => !!condition)
     .join(' AND ');
 }
 

--- a/lib/spell.js
+++ b/lib/spell.js
@@ -769,19 +769,34 @@ class Spell {
    * .order('title');
    * .order('title', 'desc');
    * .order({ title: 'desc' });
+   * .order([ 'title', 'desc' ]);
+   * .order([[ 'title','desc' ], ['id', 'asc']]);
+   * .order(['created desc', 'id asc']);
    * @param {string|Object} name
    * @param {string} direction
    * @returns {Spell}
    */
   $order(name, direction) {
-    if (isPlainObject(name)) {
+    if (Array.isArray(name) && name.length) {
+      const isMultiple = name.some(item=> Array.isArray(item));
+      if (isMultiple || name.some((item) => /^(.+?)\s+(asc|desc)$/i.test(item))) {
+        // [['created_at', 'asc'], ['id', 'desc']] or ['created desc', 'id asc']
+        name.map(cond => this.$order(cond));
+      } else if (name.length === 2 && name[0]) {
+        // ['created', 'asc']
+        this.$order(name[0], name[1]);
+      }
+    } else if (isPlainObject(name)) {
       for (const prop in name) {
         this.$order(prop, name[prop]);
       }
     }
     else if (/^(.+?)\s+(asc|desc)$/i.test(name)) {
-      [, name, direction] = name.match(/^(.+?)\s+(asc|desc)$/i);
-      this.$order(name, direction);
+      const conditions = name.split(',');
+      conditions.map(cond => {
+        [, name, direction] = cond.match(/^(.+?)\s+(asc|desc)$/i);
+        this.$order(name, direction);
+      });
     }
     else {
       this.orders.push([

--- a/test/unit/adapters/sequelize.test.js
+++ b/test/unit/adapters/sequelize.test.js
@@ -272,6 +272,36 @@ describe('=> Sequelize adapter', () => {
     assert.equal(posts.length, 1);
     assert.equal(posts[0].title, 'Leah');
     assert.throws(() => posts[0].content);
+
+    // empty id array
+    posts = await Post.findAll({
+      where: {
+        id: [],
+      }
+    });
+    assert.equal(posts.length, 2);
+
+    posts = await Post.findAll({
+      order: 'createdAt desc, id desc',
+      limit: 1,
+    });
+    assert.equal(posts.length, 1);
+    assert.equal(posts[0].title, 'Tyrael');
+
+    posts = await Post.findAll({
+      order: ['createdAt desc', 'id desc'],
+      limit: 1,
+    });
+    assert.equal(posts.length, 1);
+    assert.equal(posts[0].title, 'Tyrael');
+
+    posts = await Post.findAll({
+      order: [['createdAt', 'desc'], ['id', 'desc']],
+      limit: 1,
+    });
+    assert.equal(posts.length, 1);
+    assert.equal(posts[0].title, 'Tyrael');
+
   });
 
   it('Model.findAll(opt) with { paranoid: false }', async () => {

--- a/test/unit/spell.test.js
+++ b/test/unit/spell.test.js
@@ -436,7 +436,45 @@ describe('=> Select', function() {
       Post.order("find_in_set(id, '1,2,3')").toString(),
       "SELECT * FROM `articles` WHERE `gmt_deleted` IS NULL ORDER BY FIND_IN_SET(`id`, '1,2,3')"
     );
-  })
+  });
+
+  it('where conditions with array', () => {
+    assert.equal(
+      Post.where({ id: [ 1, 2, 3 ] }).toString(),
+      'SELECT * FROM `articles` WHERE `id` IN (1, 2, 3) AND `gmt_deleted` IS NULL'
+    );
+    // empty array
+    assert.equal(
+      Post.where({ id: [ ] }).toString(),
+      'SELECT * FROM `articles` WHERE `gmt_deleted` IS NULL'
+    );
+  });
+
+  it('order by string with multiple condition', () => {
+    assert.equal(
+      Post.order('id asc, gmt_created desc').toString(),
+      'SELECT * FROM `articles` WHERE `gmt_deleted` IS NULL ORDER BY `id`, `gmt_created` DESC'
+    );
+  });
+
+  it('order by array', () => {
+    assert.equal(
+      Post.order(['id', 'asc']).toString(),
+      'SELECT * FROM `articles` WHERE `gmt_deleted` IS NULL ORDER BY `id`'
+    );
+  });
+
+  it('order by array with multiple condition', () => {
+    assert.equal(
+      Post.order([['id', 'asc'], ['gmt_created', 'desc']]).toString(),
+      'SELECT * FROM `articles` WHERE `gmt_deleted` IS NULL ORDER BY `id`, `gmt_created` DESC'
+    );
+
+    assert.equal(
+      Post.order(['id asc', 'gmt_created desc']).toString(),
+      'SELECT * FROM `articles` WHERE `gmt_deleted` IS NULL ORDER BY `id`, `gmt_created` DESC'
+    );
+  });
 });
 
 describe('=> Update', () => {


### PR DESCRIPTION
* support orders: fixed #86
```js
 Model.order([ 'created desc', 'id asc' ]);
 Model.order([ [ 'title','desc' ], [ 'id', 'asc' ] ]); 
 Model.order([ 'title', 'desc' ]);
```

* fix where conditions contain empty array cause incorrect SQL 
```js

User.where({
  id: [ ],
});
/**
 * error: SELECT * FROM `users` WHERE `deleted_at` is NULL AND `id` in ()
 * correct: SELECT * FROM `users` WHERE `deleted_at` is NULL 
 * */

```