### PR TITLE
release: v1.4.0-alpha.1

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,13 @@
+1.4.0 / 2020-04-??
+==================
+
+  * feat: support multiple order rules in one single string or one-dimensional array (#92)
+  * feat: `realm.raw('SELECT ...')` and `Model.raw('SELECT ...')`
+  * feat: `Model.truncate()` now uses TRUNCATE if possible
+  * feat: `Model.find().optimizerHints('SET_VAR(foreign_key_checks=OFF)')`
+  * fix: make sure connection is passed around in all queries carried out within transaction
+  * docs: migrations, validations, hooks, and sequelize adapter
+
 1.3.0 / 2020-03-01
 ==================
 

--- a/lib/bone.js
+++ b/lib/bone.js
@@ -608,32 +608,32 @@ class Bone {
   /**
    * @public
    * Persist changes on current instance back to database with `UPDATE`.
-   * @param {*} opts
+   * @param {*} changes
    * @returns
    * @memberof Bone
    */
-  update(opts, queryOpts = {}) {
-    return this._update(opts, queryOpts);
+  update(changes, options = {}) {
+    return this._update(changes, options);
   }
   /**
    * Persist changes on current instance back to database with `UPDATE`.
    * @private
    * @return {number}
    */
-  _update(opts, queryOpts = {}) {
-    const changes = opts != null && typeof opts === 'object' ? opts : {};
+  _update(values, options = {}) {
+    const changes = {};
     const Model = this.constructor;
     const { attributes, primaryKey, shardingKey } = Model;
 
-    if (opts == null) {
+    if (values == null) {
       for (const name in attributes) {
         if (this.changed(name)) changes[name] = this.attribute(name);
       }
-    } else {
-      for (const name in opts) {
+    } else if (typeof values === 'object') {
+      for (const name in values) {
         const originValue = this.attribute(name);
         // exec custom setters in case it exist
-        this[name] = opts[name];
+        this[name] = values[name];
         changes[name] = this.attribute(name);
         // revert value in case update failed
         this.attribute(name, originValue);
@@ -652,10 +652,10 @@ class Bone {
     if (attributes[updatedAt] && !changes[updatedAt] && !changes[deletedAt]) {
       changes[updatedAt] = new Date();
     }
-    if (queryOpts.validate !== false ) {
+    if (options.validate !== false ) {
       this._validateAttributes(changes);
     }
-    const spell = new Spell(Model, queryOpts).$where(where).$update(changes);
+    const spell = new Spell(Model, options).$where(where).$update(changes);
     return spell.later(result => {
       // sync changes (changes has been formatted by custom setters, use this.attribute(name, value) directly)
       for (const key in changes) {
@@ -1066,27 +1066,26 @@ class Bone {
    */
   static _find(conditions, ...values) {
     const conditionsType = typeof conditions;
-    // find(1)
-    // find([ 1, 2, 3 ])
-    let spell = new Spell(this);
-    if (Array.isArray(conditions) || conditionsType == 'number') {
-      if (values.length == 1 && typeof values[0] === 'object') {
-        // pass options to spell
-        spell = new Spell(this, values[0]);
-      }
-      spell.$where({ [this.primaryKey]: conditions });
-    }
-    // find({}, { offset: 1, limit: 1, ...otherOptions })
-    else if (typeof conditions === 'object' && values.length == 1 && typeof values[0] === 'object') {
-      spell = new Spell(this, values[0]);
+    const options = values.length == 1 && typeof values[0] === 'object' ? values[0] : undefined;
+    const spell = new Spell(this, options);
 
+    if (Array.isArray(conditions) || conditionsType == 'number') {
+      // find(1)
+      // find([ 1, 2, 3 ])
+      spell.$where({ [this.primaryKey]: conditions });
+    } else if (typeof conditions === 'object' && options) {
+      // find({}, { offset: 1, limit: 1, ...etc })
       spell.$where(conditions);
+    } else if (conditions) {
+      // find('title = ?', 'foo')
+      spell.$where(conditions, ...values);
+    }
+
+    if (options) {
       for (const method of [ 'order', 'limit', 'offset', 'select' ]) {
-        const value = values[0][method];
+        const value = options[method];
         if (value != null) spell[`$${method}`](value);
       }
-    } else if (conditions) {
-      spell.$where(conditions, ...values);
     }
 
     return spell.later(Collection.init);
@@ -1144,7 +1143,7 @@ class Bone {
     });
   }
 
-  static async bulkCreate(records, queryOpts = {}) {
+  static async bulkCreate(records, options = {}) {
     const { driver, table, attributes, primaryKey, primaryColumn } = this;
 
     const { createdAt, updatedAt } = this.timestamps;
@@ -1157,7 +1156,7 @@ class Bone {
 
     const unset = records.every(entry => entry[primaryKey] == null);
     const allset = records.every(entry => entry[primaryKey] != null);
-    const opts = { ...queryOpts, attributes };
+    const opts = { ...options, attributes };
 
     if (driver.type === 'postgres') opts.returning = [ primaryColumn ];
 
@@ -1166,13 +1165,13 @@ class Bone {
       || (attribute.jsType == Number && attribute.primaryKey);
 
     // validate
-    if (queryOpts.validate !== false) {
+    if (options.validate !== false) {
       records.map(entry => this._validateAttributes(entry));
     }
 
     const instances = records.map(entry => new this(entry));
-    if (queryOpts.individualHooks) {
-      await Promise.all(instances.map((instance) => instance.save(queryOpts)));
+    if (options.individualHooks) {
+      await Promise.all(instances.map((instance) => instance.save(options)));
       return instances;
     }
 
@@ -1181,7 +1180,7 @@ class Bone {
     // 2) or none of records priamry key is set and primary key is auto incremented
     if (!(autoIncrement && unset || allset)) {
       // validate first
-      if (queryOpts.validate !== false) {
+      if (options.validate !== false) {
         records.map(record => {
           if (record instanceof Bone) record._validateAttributes();
           else this._validateAttributes(record);
@@ -1223,7 +1222,7 @@ class Bone {
    * @param {Object} values
    * @return {Spell}
    */
-  static update(conditions, values = {}, queryOption = {}) {
+  static update(conditions, values = {}, options = {}) {
     const { attributes } = this;
     // values should be immutable
     const data = Object.assign({}, values);
@@ -1232,13 +1231,13 @@ class Bone {
       data[updatedAt] = new Date();
     }
 
-    if (!queryOption || queryOption.validate !== false) {
+    if (!options || options.validate !== false) {
       // validate, values may change, deep clone it
       const validateData = copyValues(values);
       const instance = new this(validateData);
       instance._validateAttributes(validateData);
     }
-    const spell = new Spell(this, queryOption).$where(conditions).$update(data);
+    const spell = new Spell(this, options).$where(conditions).$update(data);
     return spell.later(result => {
       return result.affectedRows;
     });

--- a/lib/spell.js
+++ b/lib/spell.js
@@ -964,8 +964,8 @@ class Spell {
   /**
    * add optimizer hints to query
    * @example
-   * .optimizeHints('SET_VAR(foreign_key_checks=OFF)')
-   * .optimizeHints('SET_VAR(foreign_key_checks=OFF)', 'MAX_EXECUTION_TIME(1000)')
+   * .optimizerHints('SET_VAR(foreign_key_checks=OFF)')
+   * .optimizerHints('SET_VAR(foreign_key_checks=OFF)', 'MAX_EXECUTION_TIME(1000)')
    * @param {...string} hints
    * @returns {Spell}
    * @memberof Spell

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leoric",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "JavaScript Object-relational mapping alchemy",
   "main": "index.js",
   "types": "index.d.ts",
@@ -28,7 +28,10 @@
     "query builder",
     "sqlite"
   ],
-  "author": "cyjake (http://cyj.me)",
+  "maintainers": [
+    "cyjake (http://cyj.me)",
+    "jimmydaddy <heyjimmygo@gmail.com>"
+  ],
   "license": "BSD-3-Clause",
   "engines": {
     "node": ">= 12.0.0"


### PR DESCRIPTION
  * feat: support multiple order rules in one single string or one-dimensional array (#92)
  * feat: `realm.raw('SELECT ...')` and `Model.raw('SELECT ...')`
  * feat: `Model.truncate()` now uses TRUNCATE if possible
  * feat: `Model.find().optimizerHints('SET_VAR(foreign_key_checks=OFF)')`
  * fix: make sure connection is passed around in all queries carried out within transaction
  * docs: migrations, validations, hooks, and sequelize adapter