### PR TITLE
fix: Bone.bulkCreate() should not throw when called with non attribute

### DIFF
--- a/lib/drivers/abstract/schema.js
+++ b/lib/drivers/abstract/schema.js
@@ -182,8 +182,8 @@ module.exports = {
    * @param {Object} opts
    * @param {Object} opts.attributes
    * @param {Object} opts.returning
-   * @param {Array | boolean} updateOnDuplicate enable 'ON DUPLICATE KEY UPDATE'/'ON CONFLICT DO UPDATE SET' or not
-   * @param {Array | string} uniqueKeys ON CONFLICT (uniqueKeys) only available in Postgres and SQLite
+   * @param {Array|boolean} opts.updateOnDuplicate enable 'ON DUPLICATE KEY UPDATE'/'ON CONFLICT DO UPDATE SET' or not
+   * @param {Array|string} opts.uniqueKeys ON CONFLICT (uniqueKeys) only available in Postgres and SQLite
    */
   async bulkInsert(table, records, opts = {}) {
     const { escapeId, Attribute } = this;
@@ -191,9 +191,14 @@ module.exports = {
     const involved = records.reduce((result, entry) => {
       return Object.assign(result, entry);
     }, {});
-    const attributes = opts.attributes
-      ? Object.keys(involved).map(name => opts.attributes[name])
-      : Object.keys(involved).map(name => new Attribute(name));
+    const attributes = [];
+    if (opts.attributes) {
+      for (const name in opts.attributes) {
+        if (involved.hasOwnProperty(name)) attributes.push(opts.attributes[name]);
+      }
+    } else {
+      for (const name in involved) attributes.push(new Attribute(name));
+    }
     const columns = attributes.map(entry => escapeId(entry.columnName));
 
     const values = [];

--- a/package.json
+++ b/package.json
@@ -13,7 +13,12 @@
     "jsdoc": "rm -rf docs/api && jsdoc -c .jsdoc.json -d docs/api -t node_modules/@cara/minami",
     "pretest": "./test/prepare.sh",
     "test": "./test/start.sh",
-    "test-local": "./test/start.sh",
+    "test:local": "./test/start.sh",
+    "test:unit": "./test/start.sh unit",
+    "test:mysql": "./test/start.sh test/integration/mysql.test.js",
+    "test:mysql2": "./test/start.sh test/integration/mysql2.test.js",
+    "test:postgres": "./test/start.sh test/integration/postgres.test.js",
+    "test:sqlite": "./test/start.sh test/integration/sqlite.test.js",
     "coveralls": "./test/start.sh && nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint ./",
     "lint:fix": "eslint . --fix"

--- a/test/integration/suite/basics.test.js
+++ b/test/integration/suite/basics.test.js
@@ -977,6 +977,14 @@ describe('=> Bulk', () => {
     p2 = await Post.findOne({ id: 2 });
     assert.equal(p2.title, 'Leah');
     assert.equal(p2.authorId, 4);
+  });
 
+  it('Bone.bulkCreate() should ignore non attributes', async function() {
+    await assert.doesNotReject(async function() {
+      await Post.bulkCreate([
+        { id: 1, title: 'Tyrael', authorId: 1, missingKey: 'my precious' },
+        { id: 2, title: 'Leah', authorId: 1 },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
```js
await Post.bulkCreate([
  { missingKey: 'foo' },
]);
```