### PR TITLE
fix: leave the getter properties defined in `class` syntax as is

### DIFF
--- a/test/integration/suite/basics.test.js
+++ b/test/integration/suite/basics.test.js
@@ -417,7 +417,7 @@ describe('=> Integration', function() {
   it('bone.toJSON() with missing attributes', async function() {
     const post = await Post.findOne({ title: 'New Post' }).select('title');
     const result = post.toJSON();
-    expect(result).to.eql({ title: 'New Post', slug: '-new Post' });
+    expect(result).to.eql({ title: 'New Post', slug: 'new-post' });
   });
 
   it('bone.toJSON() prefers getter properties over bone.attribute(name)', async function() {
@@ -438,7 +438,7 @@ describe('=> Integration', function() {
   it('bone.toObject() with missing attributes', async function() {
     const post = await Post.findOne({ title: 'New Post' }).select('title');
     const result = post.toObject();
-    expect(result).to.eql({ title: 'New Post', slug: '-new Post' });
+    expect(result).to.eql({ title: 'New Post', slug: 'new-post' });
   });
 
   // the major difference between `bone.toJSON()` and `bone.toObject()`
@@ -1089,4 +1089,4 @@ describe('=> restore', () => {
     }, /Model is not paranoid/);
     assert(!await User.findOne({ nickname: 'Company Captain Yorshka' }));
   });
-})
+});

--- a/test/integration/suite/querying.test.js
+++ b/test/integration/suite/querying.test.js
@@ -374,22 +374,22 @@ describe('=> Select', function() {
 
   it('.select(...name)', async function() {
     const post = await Post.select('id', 'title').first;
-    expect(post.toJSON()).to.eql({ id: 1, title: 'New Post', slug: '-new Post' });
+    expect(post.toJSON()).to.eql({ id: 1, title: 'New Post', slug: 'new-post' });
   });
 
   it('.select(names[])', async function() {
     const post = await Post.select(['id', 'title']).first;
-    expect(post.toJSON()).to.eql({ id: 1, title: 'New Post', slug: '-new Post' });
+    expect(post.toJSON()).to.eql({ id: 1, title: 'New Post', slug: 'new-post' });
   });
 
   it('.select(name => filter(name))', async function() {
     const post = await Post.select(name => name == 'id' || name == 'title').first;
-    expect(post.toJSON()).to.eql({ id: 1, title: 'New Post', slug: '-new Post' });
+    expect(post.toJSON()).to.eql({ id: 1, title: 'New Post', slug: 'new-post' });
   });
 
   it('.select("...name")', async function() {
     const post = await Post.select('id, title').first;
-    expect(post.toJSON()).to.eql({ id: 1, title: 'New Post', slug: '-new Post' });
+    expect(post.toJSON()).to.eql({ id: 1, title: 'New Post', slug: 'new-post' });
   });
 });
 

--- a/test/models/post.js
+++ b/test/models/post.js
@@ -25,10 +25,15 @@ class Post extends Bone {
   }
 
   get slug() {
-    return this.title.replace(/([A-Z])([a-z])/, function(m, CHR, chr) {
-      return `-${CHR.toLowerCase()}${chr}`;
-    });
+    return this.title
+      .replace(/^([A-Z])/, (m, chr) => chr.toLowerCase())
+      .replace(/ ([A-Z])/g, (m, chr) => `-${chr.toLowerCase()}`);
   }
 }
+
+Object.defineProperty(Post.prototype, 'slug', {
+  ...Object.getOwnPropertyDescriptor(Post.prototype, 'slug'),
+  enumerable: true,
+});
 
 module.exports = Post;

--- a/test/unit/utils/index.test.js
+++ b/test/unit/utils/index.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const assert = require('assert').strict;
+const { Bone } = require('../../..');
+const { getPropertyNames } = require('../../../src/utils');
+
+describe('=> getPropertyNames', function() {
+  it('should traverse up to Bone.prototype', async function() {
+    class Foo extends Bone {
+      get a() {
+        return 1;
+      }
+    }
+    Object.defineProperty(Foo.prototype, 'a', {
+      ...Object.getOwnPropertyDescriptor(Foo.prototype, 'a'),
+      enumerable: true,
+    });
+
+    class Bar extends Foo {
+      get b() {
+        return 2;
+      }
+    }
+    Object.defineProperty(Bar.prototype, 'b', {
+      ...Object.getOwnPropertyDescriptor(Bar.prototype, 'b'),
+      enumerable: true,
+    });
+
+    assert.deepEqual(getPropertyNames(new Bar()).sort(), [ 'a', 'b' ]);
+  });
+
+  it('should exclude non-enumerable property names', async function() {
+    class Foo extends Bone {
+      get a() {
+        return 1;
+      }
+      get b() {
+        return 2;
+      }
+    }
+    Object.defineProperty(Foo.prototype, 'a', {
+      ...Object.getOwnPropertyDescriptor(Foo.prototype, 'a'),
+      enumerable: true,
+    });
+
+    assert.deepEqual(getPropertyNames(new Foo()).sort(), [ 'a' ]);
+  });
+});


### PR DESCRIPTION
```js
class Foo {
  get a() {}
}
```

`foo.a` is not enumerable by default, Leoric should leave it that way. If users want them to be enumerable, they need to redefine them explicitly