### PR TITLE
fix: names defined in Bone.attributes should always be enumerable

### DIFF
--- a/src/bone.js
+++ b/src/bone.js
@@ -913,12 +913,13 @@ class Bone {
         set(value) {
           this.attribute(name, value);
         },
-        enumerable: true,
-        configurable: true,
       }, Object.keys(descriptor || {}).reduce((result, key) => {
         if (descriptor[key] != null) result[key] = descriptor[key];
         return result;
-      }, {}));
+      }, {}), {
+        enumerable: true,
+        configurable: true,
+      });
     }
     Object.defineProperties(this.prototype, descriptors);
     Object.defineProperties(this, looseReadonly({

--- a/test/integration/suite/basics.test.js
+++ b/test/integration/suite/basics.test.js
@@ -447,8 +447,7 @@ describe('=> Integration', function() {
     assert(!post.toJSON().hasOwnProperty('content'));
     assert(post.toObject().hasOwnProperty('content'));
     assert.equal(post.toObject().content, null);
-    const keys = Object.keys(Post.attributes);
-    keys.push('slug');
+    const keys = Object.keys(Post.attributes).concat('slug');
     assert.deepEqual(Object.keys(post.toObject()).sort(), keys.sort());
   });
 

--- a/test/models/post.js
+++ b/test/models/post.js
@@ -25,9 +25,16 @@ class Post extends Bone {
   }
 
   get slug() {
-    return this.title
+    return this.attribute('title')
       .replace(/^([A-Z])/, (m, chr) => chr.toLowerCase())
       .replace(/ ([A-Z])/g, (m, chr) => `-${chr.toLowerCase()}`);
+  }
+
+  // custom getters in class syntax should not make attributes not enumerable
+  get title() {
+    return this.attribute('title').replace(/^([a-z])/, function(m, chr) {
+      return chr.toUpperCase();
+    });
   }
 }
 


### PR DESCRIPTION
even if overridden by getters in class syntax