### PR TITLE
feat: support class static attributes

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -12,31 +12,33 @@ Hooks support the insertion of specific contextual operations at specific times 
 {:toc}
 
 ## Declaring
+
 You can declare Hook in the following way ：
+
 ```javascript
-// init
-Model.init(attrs, {
-  hooks: {
-    beforeCreate: () => {},
-    afterUpdate: () => {}
-  }
+// class syntax
+class User extends Bone {
+  static beforeCreate() {}
+  static afterUpdate() {}
 });
 
 // define
 Realm.define('User', attrs, {
   hooks: {
-    beforeCreate: () => {},
-    afterUpdate: () => {}
+    beforeCreate() {},
+    afterUpdate() {},
   }
 });
 ```
 
-
 ## Available Hooks：
+
 > `Model.method` means hook call by Model class,  `instance.method` means hook call by Model's instance, the arguments of hooks are slightly different for different calling methods
 
 ### create
+
 `create` supports:
+
 ```javascript
 // create hooks, args are create function's arguments
 Model.beforeCreate(args) // function's context is the instance to be created
@@ -44,16 +46,23 @@ Model.afterCreate(instance, createResult) // createResult is create function's r
 instance.beforeCreate(args)
 instance.afterCreate(instance, createResult) // function's context is the instance to be created
 ```
-**It should be noted that the function context of the hooks of `create` are the instance to be created.**
+
+**Please be noted that the function context of the hooks of `create` are the instance to be created.**
+
 ### bulkCreate
+
 `bulkCreate` supports two types of hooks:
+
 ```javascript
 // bulkCreate hooks
 Model.beforeBulkCreate(records, queryOptions) // function's context is the Model
 Model.afterBulkCreate(instances, Model) // the argument 'instances' are instances to be created
 ```
+
 ### update
+
 `update` supports:
+
 ```javascript
 // update hooks
 Model.beforeUpdate(args) // function's context is the `Model`
@@ -61,12 +70,15 @@ Model.afterUpdate(updateResult, Model)
 instance.beforeUpdate(args) // function's context is the instance to be created
 instance.afterUpdate(instance, updateResult) // function's context is the instance to be created, 'updateResult' is update function's returns.
 ```
+
 ### save
+
 `save` supports：
 ```javascript
 instance.beforeSave(options)
 instance.afterSave(instance, options)
 ```
+
 Note that calling `save` may trigger the other functions' hooks (such as `create`, `update` or `upsert`).
 
 - The `create` hook function fires when the instance is not persistent or with an unset primary key
@@ -74,13 +86,18 @@ Note that calling `save` may trigger the other functions' hooks (such as `create
 - When the instance is persistent, the hook function of `upsert` will be triggered
 
 ### upsert
+
 `upsert` supports:
+
 ```javascript
 instance.beforeUpsert(opts) // function's context is the instance
 instance.bafterUpsert(instance, upsertResult)
 ```
+
 ### remove
+
 `remove` supports:
+
 ```javascript
 Model.beforeRemove(args)
 Model.afterRemove(removeResult, Model)
@@ -89,8 +106,8 @@ instance.afterRemove(instance, removeResult)
 ```
 
 ## Table of hooks
-```javascript
 
+```javascript
 // create hooks
 Model.beforeCreate(args)
 Model.afterCreate(instance, createResult)

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -19,7 +19,7 @@ The attribute definition of the model can set whether the attribute can be `null
 const { Bone, DataTypes } = require('leoric');
 
 class User extends Bone {
-  static attributes {
+  static attributes = {
     id: { type: DataTypes.BIGINT, primaryKey: true },
     email: { type: DataTypes.STRING, allowNull: false },
     ...
@@ -39,13 +39,14 @@ User.create({ name: 'OldHunter' }); // throw LeoricValidateError('notNull'); ema
 ```
 
 ## unique
+
 You can set a unique constraint on a field using 'unique':
 
 ```javascript
 const { Bone, DataTypes } = require('leoric');
 
 class User extends Bone {
-  static attributes {
+  static attributes = {
     id: { type: DataTypes.BIGINT, primaryKey: true },
     email: { type: DataTypes.STRING, allowNull: false, unique: true },
     ...
@@ -62,65 +63,78 @@ CREATE TABLE `users` (
 */
 ```
 ## Built-in validator
+
 In addition to validators included in [validator.js](https://github.com/validatorjs/validator.js) as built-in validators, leoric also provides the following built-in validators:
+
 ```javascript
-User.init({
-  var: {
-    type: ANYTYPE,
-    validate: {
-      notIn: [['MHW', 'Bloodborne']], // Not one of them
-      notNull: true, // Can't be NULL
-      isNull: true, // Must be NULL
-      min: 1988, // MinValue
-      max: 2077, // MaxValue
-      contains: 'Handsome', // Must contains 'Handsome'
-      notContains: 'Handsome', // Mustn't contain 'Handsome'
-      regex: /^iceborne/g, // Matching RegExp
-      notRegex: /^iceborne/g, // Not matching RegExp
-      is: /^iceborne/g, // Matching RegExp
-      notEmpty: true, // not allow empty string
+class User extends Bone {
+  static attributes = {
+    var: {
+      type: ANYTYPE,
+      validate: {
+        notIn: [['MHW', 'Bloodborne']], // Not one of them
+        notNull: true, // Can't be NULL
+        isNull: true, // Must be NULL
+        min: 1988, // MinValue
+        max: 2077, // MaxValue
+        contains: 'Handsome', // Must contains 'Handsome'
+        notContains: 'Handsome', // Mustn't contain 'Handsome'
+        regex: /^iceborne/g, // Matching RegExp
+        notRegex: /^iceborne/g, // Not matching RegExp
+        is: /^iceborne/g, // Matching RegExp
+        notEmpty: true, // not allow empty string
+      }
     }
   }
-});
+}
 ```
+
 ### Custom error message
+
 The built-in validator supports customize error messages instead of the default error messages of leoric.
+
 ```javascript
-User.init({
-  var: {
-    type: ANYTYPE,
-    validate: {
-      isIn: {
-        args: [ 'MHW', 'Bloodborne' ], // 'args' are the arguments of validator
-        msg: 'OH! WHAT HAVE YOU DONE?!' // `msg` is custom error message
-      },
-      notNull: {
-        args: true,
-        msg: 'OH! WHAT HAVE YOU DONE?!'
+class User extends Bone {
+  static attributes = {
+    var: {
+      type: ANYTYPE,
+      validate: {
+        isIn: {
+          args: [ 'MHW', 'Bloodborne' ], // 'args' are the arguments of validator
+          msg: 'OH! WHAT HAVE YOU DONE?!' // `msg` is custom error message
+        },
+        notNull: {
+          args: true,
+          msg: 'OH! WHAT HAVE YOU DONE?!'
+        }
       }
     }
   }
-})
+}
 ```
+
 ## Custom validators
-leoric supports set custom validators.
-You can throw an error or return `false` from the validator while the validation fails, and Leoric will take the next step based on the returns.
+
+leoric supports set custom validators. You can throw an error or return `false` from the validator while the validation fails, and Leoric will take the next step based on the returns.
+
 ```javascript
-User.init({
-desc: {
-  type: DataTypes.STRING,
-    validate: {
-      isValid() {
-        if (this.desc && this.desc.length < 2) { // you can access attribute's value by this
-          throw new Error('Invalid desc');
-        }
-      },
-      lengthMax(value) { // the first argument is the value of attribute
-        if (value && value.length >= 10) {
-          return false;
+class User extends Bone {
+  static attributes = {
+    desc: {
+    type: DataTypes.STRING,
+      validate: {
+        isValid() {
+          if (this.desc && this.desc.length < 2) { // you can access attribute's value by this
+            throw new Error('Invalid desc');
+          }
+        },
+        lengthMax(value) { // the first argument is the value of attribute
+          if (value && value.length >= 10) {
+            return false;
+          }
         }
       }
     }
   }
-})
+}
 ```

--- a/docs/zh/hooks.md
+++ b/docs/zh/hooks.md
@@ -12,31 +12,34 @@ title: 钩子
 {:toc}
 
 ## 声明钩子
+
 可通过以下方式声明：
+
 ```javascript
-// init
-Model.init(attrs, {
-  hooks: {
-    beforeCreate: () => {},
-    afterUpdate: () => {}
-  }
+// class syntax
+class User extends Bone {
+  static beforeCreate() {}
+  static afterUpdate() {}
 });
 
 // define
 Realm.define('User', attrs, {
   hooks: {
-    beforeCreate: () => {},
-    afterUpdate: () => {}
+    beforeCreate() {},
+    afterUpdate() {},
   }
 });
 ```
 
 
 ## 支持的钩子函数：
+
 > 其中 `Model.method` 表示直接通过模型类调用方法，  `instance.method` 表示通过模型实例调用方法，针对不同的调用方式其 hook 的入参和都略有不同
 
 ### create
+
 `create`  支持以下几个钩子函数:
+
 ```javascript
 // create hooks,其中 args 为函数本身调用时的参数
 Model.beforeCreate(args) // 函数上下文为将要创建的实例
@@ -44,16 +47,23 @@ Model.afterCreate(instance, createResult)
 instance.beforeCreate(args)
 instance.afterCreate(instance, createResult) // 函数上下文为将要创建的实例
 ```
+
 **需要注意的是，`create` 的钩子函数的函数上下文 `context` 皆为将要创建的实例**
+
 ### bulkCreate
+
 `bulkCreate` 支持以下两个钩子函数，其函数上下文为模型类:
+
 ```javascript
 // bulkCreate hooks
 Model.beforeBulkCreate(records, queryOptions) // 函数上下文为 Model
 Model.afterBulkCreate(instances, Model) // instances 为批量创建的实例
 ```
+
 ### update
+
 `update` 支持以下几个钩子函数:
+
 ```javascript
 // update hooks
 Model.beforeUpdate(args) // 函数上下文为 Model
@@ -61,27 +71,34 @@ Model.afterUpdate(updateResult, Model) // 函数上下文为 Model
 instance.beforeUpdate(args) // 函数上下文为 instance
 instance.afterUpdate(instance, updateResult) // 函数上下文为 instance, updateResult 为 `update` 函数的更新结果。
 ```
+
 ### save
+
 `save` 支持以下两个钩子函数：
+
 ```javascript
 Instance.beforeSave(options)
 Instance.afterSave(instance, options)
 ```
+
 需要注意的是， `save` 属于保存操作，模型实例调用 `save` 时会根据实际情况再触发 `create` 、 `update` 或 `upsert` 的钩子函数。
 
 - 当实例是未持久化且主键未设值的数据时会触发 `create` 的钩子函数
 - 当实例是未持久化且主键已经设值的数据时 `upsert` 的钩子函数被触发
 - 当实例是已持久化的数据时会触发 `upsert` 的钩子函数
 
-
 ### upsert
+
 `upsert` 支持以下两个钩子函数:
 ```javascript
 instance.beforeUpsert(opts) // 函数上下文为 instance
 instance.bafterUpsert(instance, upsertResult) // upsertResult 为 `upsert` 执行结果。
 ```
+
 ### remove
+
 `remove` 支持以下四个钩子函数:
+
 ```javascript
 Model.beforeRemove(args)
 Model.afterRemove(removeResult, Model) // removeResult 为函数执行结果
@@ -90,9 +107,9 @@ instance.afterRemove(instance, removeResult)
 ```
 
 ## 汇总
-```javascript
 
-// create hooks,其中 args 为函数本身调用时的参数
+```javascript
+// create hooks，其中 args 为函数本身调用时的参数
 Model.beforeCreate(args) // 函数上下文为将要创建的实例
 Model.afterCreate(instance, createResult)
 instance.beforeCreate(args)

--- a/docs/zh/validations.md
+++ b/docs/zh/validations.md
@@ -12,12 +12,14 @@ title: 数据校验
 {:toc}
 
 ## allowNull 是否允许为空
+
 模型的属性定义可以设置该属性是否可为空，在进行模型同步时会根据设置条件生成相应的数据表字段属性特征( `NOT NULL` 或者 `NULL` )，且模型实例属性设值时不符合空值检查时会抛出错误
+
 ```javascript
 const { Bone, DataTypes } = require('leoric');
 
 class User extends Bone {
-  static attributes {
+  static attributes = {
     id: { type: DataTypes.BIGINT, primaryKey: true },
     email: { type: DataTypes.STRING, allowNull: false },
     ...
@@ -37,12 +39,14 @@ User.create({ name: 'OldHunter' }); // throw LeoricValidateError('notNull'); ema
 ```
 
 ## unique 唯一约束
+
 可通过 `unique` 设置字段的唯一约束
+
 ```javascript
 const { Bone, DataTypes } = require('leoric');
 
 class User extends Bone {
-  static attributes {
+  static attributes = {
     id: { type: DataTypes.BIGINT, primaryKey: true },
     email: { type: DataTypes.STRING, allowNull: false, unique: true },
     ...
@@ -58,65 +62,77 @@ CREATE TABLE `users` (
 );
 */
 ```
+
 ## 内置验证器
+
 leoric 除了提供 [validator.js](https://github.com/validatorjs/validator.js) 包含的验证器作为内置验证器外还提供以下的内置验证
+
 ```javascript
-User.init({
-  var: {
-    type: ANYTYPE,
-    validate: {
-      notIn: [['MHW', 'Bloodborne']], // 不是其中任何一个
-      notNull: true, // 不能为 NULL
-      isNull: true, // 只能为 NULL
-      min: 1988, // 最小值
-      max: 2077, // 最大值
-      contains: 'Handsome', //一定要包含**字符串
-      notContains: 'Handsome', // 不能包含 ** 字符串
-      regex: /^iceborne/g, // 匹配正则
-      notRegex: /^iceborne/g, // 不匹配这个正则
-      is: /^iceborne/g, // 匹配正则
-      notEmpty: true, // 不允许空字符串
-    }
+class User extends Bone {
+  static attributes = {
+    var: {
+      type: ANYTYPE,
+      validate: {
+        notIn: [['MHW', 'Bloodborne']], // 不是其中任何一个
+        notNull: true, // 不能为 NULL
+        isNull: true, // 只能为 NULL
+        min: 1988, // 最小值
+        max: 2077, // 最大值
+        contains: 'Handsome', //一定要包含**字符串
+        notContains: 'Handsome', // 不能包含 ** 字符串
+        regex: /^iceborne/g, // 匹配正则
+        notRegex: /^iceborne/g, // 不匹配这个正则
+        is: /^iceborne/g, // 匹配正则
+        notEmpty: true, // 不允许空字符串
+      }
+    },
   }
 });
 ```
+
 ### 自定义错误信息
+
 内置验证器支持传入自定义错误信息，验证失败时不再抛出 leoric 默认的错误信息
+
 ```javascript
-User.init({
-  var: {
-    type: ANYTYPE,
-    validate: {
-      isIn: {
-        args: [ 'MHW', 'Bloodborne' ], // args 为该内置验证器需要的参数
-        msg: 'OH! WHAT HAVE YOU DONE?!' // msg 即为自定义错误信息
-      },
-      notNull: {
-        args: true,
-        msg: 'OH! WHAT HAVE YOU DONE?!'
+class User extends Bone {
+  static attributes = {
+    var: {
+      type: ANYTYPE,
+      validate: {
+        isIn: {
+          args: [ 'MHW', 'Bloodborne' ], // args 为该内置验证器需要的参数
+          msg: 'OH! WHAT HAVE YOU DONE?!' // msg 即为自定义错误信息
+        },
+        notNull: {
+          args: true,
+          msg: 'OH! WHAT HAVE YOU DONE?!'
+        }
       }
     }
   }
-})
+}
 ```
 ## 自定义验证器
 leoric 也支持自定义验证器，只需要传入函数即可，在自定义验证器中可使用 `this` 来访问模型的函数或属性值，同时在验证不通过时你既可以在验证器中直接抛出错误，也可以返回 `false` ，leoric 会根据返回值进行下一步处理
 ```javascript
-User.init({
-desc: {
-  type: DataTypes.STRING,
-    validate: {
-      isValid() {
-        if (this.desc && this.desc.length < 2) { // 可通过 this 访问属性值
-          throw new Error('Invalid desc');
-        }
-      },
-      lengthMax(value) { //自定义验证器函数的第一个参数即为当前属性的赋值
-        if (value && value.length >= 10) {
-          return false;
+class User extends Bone {
+  static attributes = {
+    desc: {
+      type: DataTypes.STRING,
+      validate: {
+        isValid() {
+          if (this.desc && this.desc.length < 2) { // 可通过 this 访问属性值
+            throw new Error('Invalid desc');
+          }
+        },
+        lengthMax(value) { //自定义验证器函数的第一个参数即为当前属性的赋值
+          if (value && value.length >= 10) {
+            return false;
+          }
         }
       }
     }
   }
-})
+}
 ```

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ async function loadModels(Bone, models, opts) {
 
   for (const model of models) {
     model.describe();
-    model.didLoad();
+    model.initialize();
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ async function loadModels(Bone, models, opts) {
 
   for (const model of models) {
     model.describe();
+    model.didLoad();
   }
 }
 

--- a/src/bone.js
+++ b/src/bone.js
@@ -917,7 +917,7 @@ class Bone {
     const { attributes, options } = this;
     const attributeMap = {};
     const table = this.table || snakeCase(pluralize(this.name));
-    const aliasName = camelCase(pluralize(this.name || table));
+    const tableAlias = camelCase(pluralize(this.name || table));
 
     this.normalize(attributes);
     for (const name of Object.keys(attributes)) {
@@ -962,7 +962,7 @@ class Bone {
       columns,
       attributeMap,
       associations: [],
-      aliasName,
+      tableAlias,
       synchronized: Object.keys(compare(attributes, columns)).length === 0,
     }));
   }

--- a/src/bone.js
+++ b/src/bone.js
@@ -982,7 +982,6 @@ class Bone {
 
   /**
    * Override this method to setup associations, rename attributes, etc.
-   * @deprecated
    * @example
    * class Post extends Bone {
    *   static didLoad() {

--- a/src/collection.js
+++ b/src/collection.js
@@ -90,13 +90,13 @@ function dispatch(spell, rows, fields) {
   }
 
   const results = new Collection();
-  const { aliasName, table, primaryColumn, primaryKey } = Model;
+  const { tableAlias, table, primaryColumn, primaryKey } = Model;
 
   for (const row of rows) {
     // If SQL contains subqueries, such as `SELECT * FROM (SELECT * FROM foo) AS bar`,
     // the table name of the columns in SQLite is the original table name instead of the alias.
     // Hence we need to fallback to original table name here.
-    const main = row[aliasName] || row[table];
+    const main = row[tableAlias] || row[table];
     let current = results.find(result => result[primaryKey] == main[primaryColumn]);
 
     if (!current) {
@@ -135,7 +135,7 @@ function dispatch(spell, rows, fields) {
 function convert(spell, rows, fields) {
   const results = [];
   const { joins } = spell;
-  const { table, aliasName } = spell.Model;
+  const { table, tableAlias } = spell.Model;
 
   // await Post.count()
   if (rows.length <= 1 && spell.columns.length === 1) {
@@ -151,12 +151,12 @@ function convert(spell, rows, fields) {
     for (let prop in row) {
       const data = row[prop];
       // mysql2 sometimes nests rows with table name instead of table alias
-      const qualifier = prop == table ? aliasName : prop;
+      const qualifier = prop == table ? tableAlias : prop;
       const obj = result[qualifier] || (result[qualifier] = {});
       if (qualifier == '') {
         Object.assign(obj, data);
       }
-      else if (qualifier in joins || qualifier == aliasName) {
+      else if (qualifier in joins || qualifier == tableAlias) {
         const { Model } = joins[qualifier] || spell;
         for (const columnName in data) {
           const definition = Model.attributeMap[columnName];

--- a/src/drivers/abstract/spellbook.js
+++ b/src/drivers/abstract/spellbook.js
@@ -15,7 +15,7 @@ const { precedes, copyExpr, findExpr, walkExpr } = require('../../expr');
  */
 function findModel(spell, qualifiers) {
   const qualifier = qualifiers && qualifiers[0];
-  const Model = qualifier && qualifier != spell.Model.aliasName
+  const Model = qualifier && qualifier != spell.Model.tableAlias
     ? (spell.joins.hasOwnProperty(qualifier) ? spell.joins[qualifier].Model : null)
     : spell.Model;
   if (!Model) throw new Error(`Unabled to find model ${qualifiers}`);
@@ -362,7 +362,7 @@ function formatSelectWithoutJoin(spell) {
  */
 function createSubspell(spell) {
   const { Model, columns, joins, whereConditions, orders } = spell;
-  const baseName = Model.aliasName;
+  const baseName = Model.tableAlias;
   const subspell = spell.dup;
 
   subspell.columns = [];
@@ -424,7 +424,7 @@ function createSubspell(spell) {
  */
 function qualify(spell) {
   const { Model, columns, groups, whereConditions, havingConditions, orders } = spell;
-  const baseName = Model.aliasName;
+  const baseName = Model.tableAlias;
   const clarify = node => {
     if (node.type === 'id' && !node.qualifiers) {
       if (Model.attributes[node.value]) node.qualifiers = [baseName];
@@ -447,7 +447,7 @@ function qualify(spell) {
 function formatSelectExpr(spell, values) {
   const { Model, columns, joins, groups } = spell;
   const { escapeId } = Model.driver;
-  const baseName = Model.aliasName;
+  const baseName = Model.tableAlias;
   const selects = new Set();
   const map = {};
 
@@ -485,7 +485,7 @@ function formatSelectWithJoin(spell) {
 
   const { Model, whereConditions, groups, havingConditions, orders, rowCount, skip, joins } = spell;
   const { escapeId } = Model.driver;
-  const baseName = Model.aliasName;
+  const baseName = Model.tableAlias;
 
   const chunks = ['SELECT'];
   const values = [];
@@ -641,7 +641,7 @@ function formatInsert(spell) {
         attributes.push(Model.attributes[name]);
       }
     }
-    
+
     columns = attributes.map(entry => entry.columnName);
 
     for (const entry of sets) {
@@ -672,7 +672,7 @@ function formatInsert(spell) {
       }
     }
   }
-  
+
 
   const chunks = ['INSERT'];
 
@@ -800,7 +800,7 @@ function formatUpdateOnDuplicate(spell, columns) {
 }
 
 /**
- * @param {Spell} spell 
+ * @param {Spell} spell
  * @returns returning sql string
  */
 function formatReturning(spell) {

--- a/src/drivers/postgres/index.js
+++ b/src/drivers/postgres/index.js
@@ -58,7 +58,7 @@ function cast(value, field) {
  */
 function nest(rows, fields, spell) {
   const results = [];
-  const qualifiers = [ spell.Model.aliasName, ...Object.keys(spell.joins) ];
+  const qualifiers = [ spell.Model.tableAlias, ...Object.keys(spell.joins) ];
   let defaultTableIndex = 0;
 
   if (spell.groups.length > 0 && Object.keys(spell.joins).length > 0) {

--- a/src/drivers/sqlite/index.js
+++ b/src/drivers/sqlite/index.js
@@ -13,7 +13,7 @@ const spellbook = require('./spellbook');
 // => [ { users: { id, ... } } ]
 function nest(rows, fields, spell) {
   const { Model } = spell;
-  const { aliasName } = Model;
+  const { tableAlias } = Model;
   const results = [];
 
   for (const row of rows) {
@@ -23,7 +23,7 @@ function nest(rows, fields, spell) {
       const parts = key.split(':');
       const [qualifier, column] = qualified
         ? (parts.length > 1 ? parts : ['', key])
-        : [Model.attributeMap.hasOwnProperty(key) ? aliasName : '', key];
+        : [Model.attributeMap.hasOwnProperty(key) ? tableAlias : '', key];
       const obj = result[qualifier] || (result[qualifier] = {});
       obj[column] = row[key];
     }

--- a/src/drivers/sqlite/spellbook.js
+++ b/src/drivers/sqlite/spellbook.js
@@ -9,15 +9,15 @@ function renameSelectExpr(spell) {
   for (const token of columns) {
     if (token.type == 'id') {
       if (!token.qualifiers && Model.attributes[token.value]) {
-        token.qualifiers = [Model.aliasName];
+        token.qualifiers = [Model.tableAlias];
       }
       whitelist.add(token.qualifiers[0]);
     }
   }
 
-  for (const qualifier of [Model.aliasName].concat(Object.keys(joins))) {
+  for (const qualifier of [Model.tableAlias].concat(Object.keys(joins))) {
     if (!whitelist.has(qualifier) && !groups.length > 0) {
-      const model = qualifier == Model.aliasName ? Model : joins[qualifier].Model;
+      const model = qualifier == Model.tableAlias ? Model : joins[qualifier].Model;
       for (const definition of model.columns) {
         const value = definition.columnName;
         columns.push({ type: 'id', qualifiers: [qualifier], value });

--- a/src/setup_hooks.js
+++ b/src/setup_hooks.js
@@ -117,6 +117,13 @@ const hookType = {
   AFTER: 'after',
 };
 
+const hookNames = hookableMethods.reduce(function(result, method) {
+  for (const prefix of Object.values(hookType)) {
+    result.push(prefix + method[0].toUpperCase() + method.slice(1));
+  }
+  return result;
+}, []);
+
 function addHook(target, hookName, func) {
   const { type, method } = getFnType(hookName);
   const sequelize = target.sequelize;
@@ -189,4 +196,5 @@ function setupSingleHook(target, hookName, func) {
 module.exports = {
   setupHooks,
   setupSingleHook,
+  hookNames,
 };

--- a/src/spell.js
+++ b/src/spell.js
@@ -391,7 +391,7 @@ function findAssociation(associations, opts) {
  * Parse associations into spell.joins
  * @param {Spell}  spell     - An instance of spell
  * @param {Model}  BaseModel - A subclass of Bone
- * @param {string} baseName  - Might be Model.aliasName, Model.table, or other names given by users
+ * @param {string} baseName  - Might be Model.tableAlias, Model.table, or other names given by users
  * @param {string} refName   - The name of the join target
  * @param {Object} opts      - Extra options such as { select, throughAssociation }
  */
@@ -959,10 +959,10 @@ class Spell {
     for (const qualifier of qualifiers) {
       if (isPlainObject(qualifier)) {
         for (const key in qualifier) {
-          joinAssociation(this, this.Model, this.Model.aliasName, key, qualifier[key]);
+          joinAssociation(this, this.Model, this.Model.tableAlias, key, qualifier[key]);
         }
       } else {
-        joinAssociation(this, this.Model, this.Model.aliasName, qualifier);
+        joinAssociation(this, this.Model, this.Model.tableAlias, qualifier);
       }
     }
     return this;
@@ -983,7 +983,7 @@ class Spell {
     if (typeof Model == 'string') {
       return this.$with(...arguments);
     }
-    const qualifier = Model.aliasName;
+    const qualifier = Model.tableAlias;
     const { joins } = this;
 
     if (qualifier in joins) {

--- a/test/integration/suite/definitions.test.js
+++ b/test/integration/suite/definitions.test.js
@@ -141,11 +141,11 @@ describe('=> Bone.sync()', () => {
   it('should create table if not exists', async () => {
     class Note extends Bone {};
     Note.init({ title: STRING, body: TEXT });
-    assert.equal(Note.table, 'notes');
     assert(!Note.synchronized);
 
     await Note.sync();
     assert(Note.synchronized);
+    assert.equal(Note.table, 'notes');
     await checkDefinitions('notes', {
       title: { dataType: 'varchar' },
     });

--- a/test/models/attachment.js
+++ b/test/models/attachment.js
@@ -3,7 +3,7 @@
 const { Bone } = require('../..');
 
 class Attachment extends Bone {
-  static describe() {
+  static initialize() {
     this.renameAttribute('articleId', 'postId');
     this.belongsTo('post', {
       foreignKey: 'postId'

--- a/test/models/comment.js
+++ b/test/models/comment.js
@@ -3,7 +3,7 @@
 const { Bone } = require('../..');
 
 class Comment extends Bone {
-  static describe() {
+  static initialize() {
     this.belongsTo('post', {
       foreignKey: 'articleId'
     });

--- a/test/models/post.js
+++ b/test/models/post.js
@@ -3,11 +3,9 @@
 const { Bone } = require('../..');
 
 class Post extends Bone {
-  static get table() {
-    return 'articles';
-  }
+  static table = 'articles';
 
-  static describe() {
+  static initialize() {
     this.hasOne('attachment', {
       foreignKey: 'postId'
     });

--- a/test/models/tag.js
+++ b/test/models/tag.js
@@ -15,32 +15,27 @@ function uid() {
 }
 
 class Tag extends Bone {
-  static describe() {
-  }
-}
-
-Tag.init({
-  id: {
-    primaryKey: true,
-    type: DataTypes.BIGINT
-  },
-  createdAt: { type: DataTypes.DATE, columnName: 'gmt_create' },
-  updatedAt: { type: DataTypes.DATE, columnName: 'gmt_modified' },
-  deletedAt: { type: DataTypes.DATE, columnName: 'gmt_deleted' },
-  type:  DataTypes.INT,
-  name: DataTypes.STRING,
-  uuid: {
-    type: DataTypes.STRING,
-    unique: true,
-  }
-}, {
-  hooks: {
-    beforeCreate(obj) {
-      if (!obj.uuid) {
-        obj.uuid = uid();
-      }
+  static attributes = {
+    id: {
+      primaryKey: true,
+      type: DataTypes.BIGINT
+    },
+    createdAt: { type: DataTypes.DATE, columnName: 'gmt_create' },
+    updatedAt: { type: DataTypes.DATE, columnName: 'gmt_modified' },
+    deletedAt: { type: DataTypes.DATE, columnName: 'gmt_deleted' },
+    type:  DataTypes.INT,
+    name: DataTypes.STRING,
+    uuid: {
+      type: DataTypes.STRING,
+      unique: true,
     }
   }
-});
+
+  static beforeCreate(obj) {
+    if (!obj.uuid) {
+      obj.uuid = uid();
+    }
+  }
+}
 
 module.exports = Tag;

--- a/test/models/tagMap.js
+++ b/test/models/tagMap.js
@@ -3,7 +3,7 @@
 const { Bone } = require('../..');
 
 class TagMap extends Bone {
-  static describe() {
+  static initialize() {
     this.belongsTo('post', {
       foreignKey: 'targetId',
       where: { targetType: 0 }

--- a/test/unit/bone.test.js
+++ b/test/unit/bone.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const assert = require('assert').strict;
+const { Bone, DataTypes, connect } = require('../..');
+
+const { BIGINT, STRING, DATE } = DataTypes;
+
+describe('=> Bone.init()', function() {
+  it('should be able to initialize attributes', async function() {
+    class User extends Bone {}
+    User.init({ name: STRING });
+    assert.ok(User.attributes.name);
+  });
+
+  it('should leave table name undefined if not specified', async function() {
+    class User extends Bone {}
+    User.init({ name: STRING });
+    assert.equal(User.table, undefined);
+  });
+
+  it('should be able to override table name', async function() {
+    class User extends Bone {}
+    User.init({ name: STRING }, { tableName: 'people' });
+    assert.ok(User.attributes.name);
+    assert.equal(User.table, 'people');
+  });
+});
+
+describe('=> Bone.normalize(attributes)', function() {
+  it('should append primary key if no primary key were found', async function() {
+    const attributes = {};
+    Bone.normalize(attributes);
+    assert.ok(attributes.id);
+    assert.ok(attributes.id.primaryKey);
+    assert.equal(attributes.id.type.toSqlString(), 'BIGINT');
+  });
+
+  it('should not append primary key if primary key exists', async function() {
+    const attributes = {
+      iid: { type: BIGINT, primaryKey: true },
+    };
+    Bone.normalize(attributes);
+    assert.equal(attributes.iid.primaryKey, true);
+    assert.equal(attributes.id, undefined);
+  });
+
+  it('should rename legacy timestamps', async function() {
+    const attributes = {
+      gmtCreate: DATE,
+      gmtModified: DATE,
+      gmtDeleted: DATE,
+    };
+    Bone.normalize(attributes);
+    assert.ok(attributes.createdAt);
+    assert.ok(attributes.updatedAt);
+    assert.ok(attributes.deletedAt);
+    assert.equal(attributes.gmtCreate, undefined);
+    assert.equal(attributes.gmtModified, undefined);
+    assert.equal(attributes.gmtDeleted, undefined);
+  });
+});
+
+describe('=> Bone.load()', function() {
+  beforeEach(async function() {
+    await connect({
+      port: process.env.MYSQL_PORT,
+      user: 'root',
+      database: 'leoric',
+    });
+  });
+
+  afterEach(function() {
+    Bone.driver = null;
+  });
+
+  it('should make sure attributes are initialized before load', async function() {
+    class User extends Bone {
+      static attributes = {
+        name: STRING,
+      }
+    }
+    User.load([
+      { columnName: 'id', columnType: 'bigint', dataType: 'bigint', primaryKey: true },
+      { columnName: 'name', columnType: 'varchar', dataType: 'varchar' },
+    ]);
+    assert.ok(User.attributes);
+    assert.equal(User.table, 'users');
+    assert.equal(User.primaryKey, 'id');
+  });
+
+  it('should mark timestamps', async function() {
+    class User extends Bone {
+      static attributes = {
+        createdAt: DATE,
+        updatedAt: DATE,
+        deletedAt: DATE,
+      }
+    }
+    User.load([
+      { columnName: 'id', columnType: 'bigint', dataType: 'bigint', primaryKey: true },
+      { columnName: 'created_at', columnType: 'timestamp', dataType: 'timestamp' },
+      { columnName: 'updated_at', columnType: 'timestamp', dataType: 'timestamp' },
+      { columnName: 'deleted_at', columnType: 'timestamp', dataType: 'timestamp' },
+    ]);
+    assert.ok(User.timestamps);
+    assert.equal(User.timestamps.createdAt, 'createdAt');
+    assert.equal(User.timestamps.updatedAt, 'updatedAt');
+    assert.equal(User.timestamps.deletedAt, 'deletedAt');
+  });
+
+  it('should mark primaryKey', async function() {
+    class User extends Bone {
+      static attributes = {
+        ssn: { type: STRING, primaryKey: true },
+      }
+    }
+    User.load([
+      { columnName: 'ssn', columnType: 'varchar', dataType: 'varchar', primaryKey: true },
+    ]);
+    assert.equal(User.primaryKey, 'ssn');
+    assert.equal(User.primaryColumn, 'ssn');
+  });
+});

--- a/test/unit/connect.test.js
+++ b/test/unit/connect.test.js
@@ -39,11 +39,12 @@ describe('connect', function() {
 
   it('connect models passed in opts.models (init with primaryKey)', async function() {
     const { STRING, BIGINT } = DataTypes;
-    class Book extends Bone {};
-    Book.init({
-      isbn: { type: BIGINT, primaryKey: true },
-      name: { type: STRING, allowNull: false },
-    });
+    class Book extends Bone {
+      static attributes = {
+        isbn: { type: BIGINT, primaryKey: true },
+        name: { type: STRING, allowNull: false },
+      }
+    }
     await connect({
       port: process.env.MYSQL_PORT,
       user: 'root',
@@ -59,13 +60,11 @@ describe('connect', function() {
   it('connect models passed in opts.models (define class with primaryKey)', async function() {
     const { STRING } = DataTypes;
     class Book extends Bone {
-      static get primaryKey() {
-        return 'isbn';
-      }
-    };
-    Book.init({
-      name: { type: STRING, allowNull: false },
-    });
+      static primaryKey = 'isbn';
+      static attributes = {
+        name: { type: STRING, allowNull: false },
+      };
+    }
     await connect({
       port: process.env.MYSQL_PORT,
       user: 'root',
@@ -101,5 +100,21 @@ describe('connect', function() {
     const user = await User.create({ email: 'hello@hh.com', nickname: 'testy', meta: { foo: 1, bar: 'baz'} });
     assert(user.email === 'hello@hh.com');
     assert(user.meta.foo === 1);
+  });
+
+  it('should call customized initialize code in model', async function() {
+    let initialized;
+    class User extends Bone {
+      static initialize() {
+        initialized = true;
+      }
+    }
+    await connect({
+      port: process.env.MYSQL_PORT,
+      user: 'root',
+      database: 'leoric',
+      models: [ User ],
+    });
+    assert(initialized);
   });
 });

--- a/test/unit/realm.test.js
+++ b/test/unit/realm.test.js
@@ -454,15 +454,12 @@ describe('=> Realm', () => {
       });
 
       it('should work with find', async () => {
-        const user1 = await User.create({ nickname: 'tim', email: 'h@h.com' ,meta: { foo: 1, bar: 'baz'}, status: 1 });
-        await User.create({ nickname: 'tim1', email: 'h1@h.com' ,meta: { foo: 1, bar: 'baz'}, status: 1 });
-
-        const user2 = new User({
-          nickname: 'tim', email: 'h2@h.com', status: 1
-        });
+        const user1 = await User.create({ nickname: 'tim', email: 'h@h.com', meta: { foo: 1, bar: 'baz'}, status: 1 });
+        await User.create({ nickname: 'tim1', email: 'h1@h.com', meta: { foo: 1, bar: 'baz'}, status: 1 });
 
         await assert.rejects(async () => {
           await Bone.transaction(async ({ connection }) => {
+            const user2 = new User({ nickname: 'tim', email: 'h2@h.com', status: 1 });
             await user2.save({ connection });
             const users = await User.find({
               nickname: 'tim',
@@ -478,11 +475,9 @@ describe('=> Realm', () => {
         });
         assert(!userRes);
 
-        // TODO How to rollback value assigning ?
-        user2.id = undefined;
-
         await assert.rejects(async () => {
           await Bone.transaction(async ({ connection }) => {
+            const user2 = new User({ nickname: 'tim', email: 'h2@h.com', status: 1 });
             await user2.save({ connection });
             const users = await User.find([ user1.id, user2.id ], { connection });
             if (users.length >= 2 && users[0].nickname === 'tim' && users[1].nickname === 'tim') {


### PR DESCRIPTION
```js
class User extends Bone {
  static attributes = {}
  static beforeCreate(obj) {
  }
  static initialize() {
    this.hasMany('posts');
  }
}
```

- deprecated `Bone.describe()`, migrating to `Bone.initialize()`.
- renamed `Bone.aliasName` to `Bone.tableAlias`, which is an internal property