### PR TITLE
fix: collection convert should handle tddl results as well

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -134,15 +134,16 @@ function dispatch(spell, rows, fields) {
  */
 function convert(spell, rows, fields) {
   const results = [];
-  const { joins } = spell;
+  const { groups, joins, columns } = spell;
   const { table, tableAlias } = spell.Model;
 
   // await Post.count()
-  if (rows.length <= 1 && spell.columns.length === 1) {
-    const { type, value, args } = spell.columns[0];
+  if (rows.length <= 1 && columns.length === 1 && groups.length === 0) {
+    const { type, value, args } = columns[0];
     if (type === 'alias' && args && args[0].type === 'func') {
       const row = rows[0];
-      return row && row[''] && row[''][value] || 0;
+      const result = row && (row[''] || row[table]);
+      return result && result[value] || 0;
     }
   }
 

--- a/test/unit/collection.test.js
+++ b/test/unit/collection.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const assert = require('assert').strict;
+const { Bone, Collection, connect } = require('../..');
+
+describe('=> Collection', function() {
+  class Post extends Bone {
+    static table = 'articles'
+  }
+
+  before(async function() {
+    await connect({
+      models: [ Post ],
+      database: 'leoric',
+      user: 'root',
+      port: process.env.MYSQL_PORT,
+    });
+  });
+
+  it('should destruct result if query is simple aggregate', async function() {
+    const result = Collection.init({
+      spell: Post.count(),
+      rows: [ { '': { count: 1 } } ],
+      fields: [],
+    });
+    assert.equal(result, 1);
+  });
+
+  it('should accept table as result qualifier as well', async function() {
+    const result = Collection.init({
+      spell: Post.count(),
+      rows: [ { articles: { count: 1 } } ],
+      fields: [],
+    });
+    assert.equal(result, 1);
+  });
+
+  it('should not destruct result if query is grouped', async function() {
+    const result = Collection.init({
+      spell: Post.group('author_id').count(),
+      rows: [ { '': { count: 1 } } ],
+      fields: [],
+    });
+    // merge the qualifier layer
+    assert.deepEqual(result, [ { count: 1 } ]);
+  });
+});


### PR DESCRIPTION
- vanilla mysql: `[ { '': { count: 1 } } ]`
- tddl: `[ { [table]: { count: 1 } } ]`