### PR TITLE
fix: renamed attribute should remain enumerable

### DIFF
--- a/src/adapters/sequelize.js
+++ b/src/adapters/sequelize.js
@@ -126,6 +126,10 @@ module.exports = Bone => {
       return true;
     }
 
+    static get Instance() {
+      return this;
+    }
+
     /**
      * add scope see https://sequelize.org/master/class/lib/model.js~Model.html#static-method-addScope
      *

--- a/src/bone.js
+++ b/src/bone.js
@@ -935,9 +935,7 @@ class Bone {
       }
     }
 
-    const descriptors = {};
     for (const name in attributes) this.loadAttribute(name);
-    Object.defineProperties(this.prototype, descriptors);
 
     Object.defineProperties(this, looseReadonly({
       timestamps,

--- a/src/bone.js
+++ b/src/bone.js
@@ -936,23 +936,7 @@ class Bone {
     }
 
     const descriptors = {};
-    for (const name in attributes) {
-      const descriptor = Object.getOwnPropertyDescriptor(this.prototype, name);
-      descriptors[name] = Object.assign({
-        get() {
-          return this.attribute(name);
-        },
-        set(value) {
-          this.attribute(name, value);
-        },
-      }, Object.keys(descriptor || {}).reduce((result, key) => {
-        if (descriptor[key] != null) result[key] = descriptor[key];
-        return result;
-      }, {}), {
-        enumerable: true,
-        configurable: true,
-      });
-    }
+    for (const name in attributes) this.loadAttribute(name);
     Object.defineProperties(this.prototype, descriptors);
 
     Object.defineProperties(this, looseReadonly({
@@ -1046,6 +1030,29 @@ class Bone {
   }
 
   /**
+   * Load attribute definition to merge default getter/setter and custom descriptor on prototype
+   * @param {string} name attribute name
+   */
+  static loadAttribute(name) {
+    const descriptor = Object.getOwnPropertyDescriptor(this.prototype, name);
+    const customDescriptor = Object.keys(descriptor || {}).reduce((result, key) => {
+      if (descriptor[key] != null) result[key] = descriptor[key];
+      return result;
+    }, {});
+    Object.defineProperty(this.prototype, name, {
+      get() {
+        return this.attribute(name);
+      },
+      set(value) {
+        return this.attribute(name, value);
+      },
+      ...customDescriptor,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+
+  /**
    * Rename attribute. Since Bone manages a separate set of names called attributes instead of using the raw columns, we can rename the attribute names, which is transformed from the column names by convention, to whatever name we fancy.
    * @param {string} originalName
    * @param {string} newName
@@ -1064,16 +1071,7 @@ class Bone {
       attributeMap[info.columnName] = info;
       delete attributes[originalName];
       Reflect.deleteProperty(this.prototype, originalName);
-      Object.defineProperty(this.prototype, newName, Object.assign({
-        get() {
-          return this.attribute(newName);
-        },
-        set(value) {
-          return this.attribute(newName, value);
-        },
-        enumerable: true,
-        configurable: true,
-      }, Object.getOwnPropertyDescriptor(this.prototype, newName)));
+      this.loadAttribute(newName);
     }
   }
 

--- a/test/unit/adapters/sequelize.test.js
+++ b/test/unit/adapters/sequelize.test.js
@@ -201,7 +201,6 @@ describe('=> Sequelize adapter', () => {
     assert.equal(result, 1);
   });
 
-
   it('Model.count({ where, paranoid: false })', async () => {
     const books = await Promise.all([
       Post.create({ title: 'By three they come' }),
@@ -759,7 +758,6 @@ describe('=> Sequelize adapter', () => {
     assert.equal(book.price, 15);
   });
 
-
   it('model.restore()', async () => {
     const post = await Post.create({ title: 'By three they come' });
     await post.remove();
@@ -878,6 +876,11 @@ describe('=> Sequelize adapter', () => {
 
     await Book.truncate();
     assert.equal(await Book.count(), 0);
+  });
+
+  it('Model.Instance', async function() {
+    // sequelize models use Model.Instance.prototype to extend instance methods
+    assert.equal(Book.Instance, Book);
   });
 
   it('instance.dataValues', async () => {

--- a/test/unit/bone.test.js
+++ b/test/unit/bone.test.js
@@ -5,63 +5,8 @@ const { Bone, DataTypes, connect } = require('../..');
 
 const { BIGINT, STRING, DATE } = DataTypes;
 
-describe('=> Bone.init()', function() {
-  it('should be able to initialize attributes', async function() {
-    class User extends Bone {}
-    User.init({ name: STRING });
-    assert.ok(User.attributes.name);
-  });
-
-  it('should leave table name undefined if not specified', async function() {
-    class User extends Bone {}
-    User.init({ name: STRING });
-    assert.equal(User.table, undefined);
-  });
-
-  it('should be able to override table name', async function() {
-    class User extends Bone {}
-    User.init({ name: STRING }, { tableName: 'people' });
-    assert.ok(User.attributes.name);
-    assert.equal(User.table, 'people');
-  });
-});
-
-describe('=> Bone.normalize(attributes)', function() {
-  it('should append primary key if no primary key were found', async function() {
-    const attributes = {};
-    Bone.normalize(attributes);
-    assert.ok(attributes.id);
-    assert.ok(attributes.id.primaryKey);
-    assert.equal(attributes.id.type.toSqlString(), 'BIGINT');
-  });
-
-  it('should not append primary key if primary key exists', async function() {
-    const attributes = {
-      iid: { type: BIGINT, primaryKey: true },
-    };
-    Bone.normalize(attributes);
-    assert.equal(attributes.iid.primaryKey, true);
-    assert.equal(attributes.id, undefined);
-  });
-
-  it('should rename legacy timestamps', async function() {
-    const attributes = {
-      gmtCreate: DATE,
-      gmtModified: DATE,
-      gmtDeleted: DATE,
-    };
-    Bone.normalize(attributes);
-    assert.ok(attributes.createdAt);
-    assert.ok(attributes.updatedAt);
-    assert.ok(attributes.deletedAt);
-    assert.equal(attributes.gmtCreate, undefined);
-    assert.equal(attributes.gmtModified, undefined);
-    assert.equal(attributes.gmtDeleted, undefined);
-  });
-});
-
-describe('=> Bone.load()', function() {
-  beforeEach(async function() {
+describe('=> Bone', function() {
+  before(async function() {
     await connect({
       port: process.env.MYSQL_PORT,
       user: 'root',
@@ -69,55 +14,169 @@ describe('=> Bone.load()', function() {
     });
   });
 
-  afterEach(function() {
+  after(function() {
     Bone.driver = null;
   });
 
-  it('should make sure attributes are initialized before load', async function() {
-    class User extends Bone {
-      static attributes = {
-        name: STRING,
-      }
-    }
-    User.load([
-      { columnName: 'id', columnType: 'bigint', dataType: 'bigint', primaryKey: true },
-      { columnName: 'name', columnType: 'varchar', dataType: 'varchar' },
-    ]);
-    assert.ok(User.attributes);
-    assert.equal(User.table, 'users');
-    assert.equal(User.primaryKey, 'id');
+  describe('=> Bone.init()', function() {
+    it('should be able to initialize attributes', async function() {
+      class User extends Bone {}
+      User.init({ name: STRING });
+      assert.ok(User.attributes.name);
+    });
+
+    it('should leave table name undefined if not specified', async function() {
+      class User extends Bone {}
+      User.init({ name: STRING });
+      assert.equal(User.table, undefined);
+    });
+
+    it('should be able to override table name', async function() {
+      class User extends Bone {}
+      User.init({ name: STRING }, { tableName: 'people' });
+      assert.ok(User.attributes.name);
+      assert.equal(User.table, 'people');
+    });
   });
 
-  it('should mark timestamps', async function() {
-    class User extends Bone {
-      static attributes = {
-        createdAt: DATE,
-        updatedAt: DATE,
-        deletedAt: DATE,
-      }
-    }
-    User.load([
-      { columnName: 'id', columnType: 'bigint', dataType: 'bigint', primaryKey: true },
-      { columnName: 'created_at', columnType: 'timestamp', dataType: 'timestamp' },
-      { columnName: 'updated_at', columnType: 'timestamp', dataType: 'timestamp' },
-      { columnName: 'deleted_at', columnType: 'timestamp', dataType: 'timestamp' },
-    ]);
-    assert.ok(User.timestamps);
-    assert.equal(User.timestamps.createdAt, 'createdAt');
-    assert.equal(User.timestamps.updatedAt, 'updatedAt');
-    assert.equal(User.timestamps.deletedAt, 'deletedAt');
+  describe('=> Bone.normalize(attributes)', function() {
+    it('should append primary key if no primary key were found', async function() {
+      const attributes = {};
+      Bone.normalize(attributes);
+      assert.ok(attributes.id);
+      assert.ok(attributes.id.primaryKey);
+      assert.equal(attributes.id.type.toSqlString(), 'BIGINT');
+    });
+
+    it('should not append primary key if primary key exists', async function() {
+      const attributes = {
+        iid: { type: BIGINT, primaryKey: true },
+      };
+      Bone.normalize(attributes);
+      assert.equal(attributes.iid.primaryKey, true);
+      assert.equal(attributes.id, undefined);
+    });
+
+    it('should rename legacy timestamps', async function() {
+      const attributes = {
+        gmtCreate: DATE,
+        gmtModified: DATE,
+        gmtDeleted: DATE,
+      };
+      Bone.normalize(attributes);
+      assert.ok(attributes.createdAt);
+      assert.ok(attributes.updatedAt);
+      assert.ok(attributes.deletedAt);
+      assert.equal(attributes.gmtCreate, undefined);
+      assert.equal(attributes.gmtModified, undefined);
+      assert.equal(attributes.gmtDeleted, undefined);
+    });
   });
 
-  it('should mark primaryKey', async function() {
-    class User extends Bone {
-      static attributes = {
-        ssn: { type: STRING, primaryKey: true },
+  describe('=> Bone.load()', function() {
+
+
+    it('should make sure attributes are initialized before load', async function() {
+      class User extends Bone {
+        static attributes = {
+          name: STRING,
+        }
       }
-    }
-    User.load([
-      { columnName: 'ssn', columnType: 'varchar', dataType: 'varchar', primaryKey: true },
-    ]);
-    assert.equal(User.primaryKey, 'ssn');
-    assert.equal(User.primaryColumn, 'ssn');
+      User.load([
+        { columnName: 'id', columnType: 'bigint', dataType: 'bigint', primaryKey: true },
+        { columnName: 'name', columnType: 'varchar', dataType: 'varchar' },
+      ]);
+      assert.ok(User.attributes);
+      assert.equal(User.table, 'users');
+      assert.equal(User.primaryKey, 'id');
+    });
+
+    it('should mark timestamps', async function() {
+      class User extends Bone {
+        static attributes = {
+          createdAt: DATE,
+          updatedAt: DATE,
+          deletedAt: DATE,
+        }
+      }
+      User.load([
+        { columnName: 'id', columnType: 'bigint', dataType: 'bigint', primaryKey: true },
+        { columnName: 'created_at', columnType: 'timestamp', dataType: 'timestamp' },
+        { columnName: 'updated_at', columnType: 'timestamp', dataType: 'timestamp' },
+        { columnName: 'deleted_at', columnType: 'timestamp', dataType: 'timestamp' },
+      ]);
+      assert.ok(User.timestamps);
+      assert.equal(User.timestamps.createdAt, 'createdAt');
+      assert.equal(User.timestamps.updatedAt, 'updatedAt');
+      assert.equal(User.timestamps.deletedAt, 'deletedAt');
+    });
+
+    it('should mark primaryKey', async function() {
+      class User extends Bone {
+        static attributes = {
+          ssn: { type: STRING, primaryKey: true },
+        }
+      }
+      User.load([
+        { columnName: 'ssn', columnType: 'varchar', dataType: 'varchar', primaryKey: true },
+      ]);
+      assert.equal(User.primaryKey, 'ssn');
+      assert.equal(User.primaryColumn, 'ssn');
+    });
+  });
+
+  describe('=> Bone.loadAttribute()', function() {
+    it('should make the loaded attribute enumerable', async function() {
+      class User extends Bone {}
+      User.loadAttribute('foo');
+      assert.ok(Object.getOwnPropertyDescriptor(User.prototype, 'foo').enumerable);
+    });
+
+    it('should make sure both getter and setter exist', async function() {
+      class User extends Bone {
+        get foo() {
+          return this.attribute('foo');
+        }
+      }
+      User.loadAttribute('foo');
+      assert.ok(Object.getOwnPropertyDescriptor(User.prototype, 'foo').enumerable);
+      assert.ok(Object.getOwnPropertyDescriptor(User.prototype, 'foo').set);
+    });
+  });
+
+  describe('=> Bone.renameAttribute()', function() {
+    it('should make the renamed attribute enumerable', async function() {
+      class User extends Bone {
+        static attributes = {
+          foo: { type: STRING },
+        }
+      }
+      User.load([
+        { columnName: 'foo', columnType: 'varchar', dataType: 'varchar' },
+      ]);
+      User.renameAttribute('foo', 'bar');
+      assert.ok(Object.getOwnPropertyDescriptor(User.prototype, 'bar').enumerable);
+    });
+
+    it('should still be enumerable event if there were getter', async function() {
+      class User extends Bone {
+        static attributes = {
+          foo: { type: STRING },
+        }
+        get bar() {
+          return this.attribute('bar');
+        }
+      }
+      User.load([
+        { columnName: 'foo', columnType: 'varchar', dataType: 'varchar' },
+      ]);
+      User.renameAttribute('foo', 'bar');
+      assert.ok(Object.getOwnPropertyDescriptor(User.prototype, 'bar').enumerable);
+      assert.doesNotThrow(function() {
+        const user = new User();
+        user.bar = 1;
+        assert.equal(user.bar, 1);
+      }, /TypeError: Cannot set property bar/);
+    });
   });
 });


### PR DESCRIPTION
even if there is getter method with same name. Also added `Model.Instance` in sequelize adapter