### PR TITLE
fix: transaction option passing in sequelize adapter

### DIFF
--- a/src/spell.js
+++ b/src/spell.js
@@ -533,6 +533,7 @@ class Spell {
 
     this.laters = [];
 
+    // transaction options is passed around in opts.transaction in sequelize adapter
     Object.assign(this, {
       command: 'select',
       columns: [],
@@ -544,7 +545,7 @@ class Spell {
       joins: {},
       skip: 0,
       subqueryIndex: 0
-    }, opts);
+    }, opts.transaction, opts);
 
     const hints = [];
 


### PR DESCRIPTION
```js
// sequelize
await realm.transaction(async function(transaction) {
  await User.create(values, { transaction })
});

// leoric
await realm.transaction(async function({ connection }) {
  await User.create(values, { connection })
});
```

Connection will be passed to Spell in `opts.transaction`