### PR TITLE
fix: describe table with more compatible syntax

### DIFF
--- a/src/drivers/abstract/schema.js
+++ b/src/drivers/abstract/schema.js
@@ -31,7 +31,7 @@ module.exports = {
 
   async describeTable(table) {
     const { escapeId } = this;
-    await this.query(`DESCRIBE TABLE ${escapeId(table)}`);
+    await this.query(`DESCRIBE ${escapeId(table)}`);
   },
 
   async addColumn(table, name, params) {


### PR DESCRIPTION
```
[query] [85564] DESCRIBE TABLE `activities`
2021-07-15 16:28:22,908 ERROR 754 nodejs.unhandledRejectionError: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'TABLE `activities`' at line 1
    at Packet.asError (./node_modules/_mysql2@1.7.0@mysql2/lib/packets/packet.js:708:17)
    at Query.execute (./node_modules/_mysql2@1.7.0@mysql2/lib/commands/command.js:28:26)
    at PoolConnection.handlePacket (./node_modules/_mysql2@1.7.0@mysql2/lib/connection.js:408:32)
    at PacketParser.onPacket (./node_modules/_mysql2@1.7.0@mysql2/lib/connection.js:70:12)
    at PacketParser.executeStart (./node_modules/_mysql2@1.7.0@mysql2/lib/packet_parser.js:75:16)
    at Socket.<anonymous> (./node_modules/_mysql2@1.7.0@mysql2/lib/connection.js:77:25)
    at Socket.emit (events.js:315:20)
    at Socket.EventEmitter.emit (domain.js:467:12)
    at addChunk (internal/streams/readable.js:309:12)
    at readableAddChunk (internal/streams/readable.js:284:9)
    at Socket.Readable.push (internal/streams/readable.js:223:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:188:23)
```