### PR TITLE
refactor: connect({ Bone }) still necessary

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,7 @@
     "no-underscore-dangle": 0,
     "no-use-before-define": [2, "nofunc"],
     "no-unused-vars": [2, { "vars": "all", "args": "none", "ignoreRestSiblings": true }],
+    "no-shadow": 2,
     "keyword-spacing": "error",
     "eol-last": "error"
   }

--- a/docs/contributing/guides.md
+++ b/docs/contributing/guides.md
@@ -23,17 +23,33 @@ $ brew service start postgres
 
 ```bash
 $ npm install
+# prepare table schema, run all tests
+$ npm run test
 # run unit tests
-$ npm test unit
+$ npm run test:unit
 # run integration tests
-$ npm test integration
+$ npm run test:integration
 ```
 
 To be more specific, we can filter test files and cases:
 
 ```bash
 $ npm run test -- test/unit/test.connect.js --grep "should work"
+$ npm run test:unit --grep "=> Sequelize adapter"
+$ npm run test:mysql --grep "bone.toJSON()"
 ```
+
+If `--grep [pattern]` isn't specific enough, we can always insert `.only`:
+
+```js
+describe('=> Spell', function() {
+  it.only('supports error convention with nodeify', async function() {
+    // asserts
+  });
+});
+```
+
+Please remember to remove them before commit.
 
 ## Working on Documentations
 

--- a/docs/zh/contributing/guides.md
+++ b/docs/zh/contributing/guides.md
@@ -28,16 +28,30 @@ $ npm install
 # 初始化表结构，运行所有测试
 $ npm run test
 # 仅运行单元测试
-$ npm test unit
+$ npm run test:unit
 # 仅运行集成测试
-$ npm test integration
+$ npm run test:integration
 ```
 
 还可以执行单个测试文件，或者使用 `--grep` 选项进一步限定执行范围：
 
 ```bash
 $ npm run test -- test/unit/test.connect.js --grep "should work"
+$ npm run test:unit -- --grep "=> Sequelize adapter"
+$ npm run test:mysql -- --grep "bone.toJSON()"
 ```
+
+如果 `--grep [pattern]` 不够直观，也可以随时改成用 `.only` 来指定用例：
+
+```js
+describe('=> Spell', function() {
+  it.only('supports error convention with nodeify', async function() {
+    // asserts
+  });
+});
+```
+
+提交代码之前记得将 `.only` 移除掉。
 
 ## 编写帮助文档
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "./test/start.sh",
     "test:local": "./test/start.sh",
     "test:unit": "./test/start.sh unit",
+    "test:integration": "./test/start.sh integration",
     "test:mysql": "./test/start.sh test/integration/mysql.test.js",
     "test:mysql2": "./test/start.sh test/integration/mysql2.test.js",
     "test:postgres": "./test/start.sh test/integration/postgres.test.js",

--- a/src/spell.js
+++ b/src/spell.js
@@ -937,11 +937,11 @@ class Spell {
     this.$having(conditions, ...values);
     const { havingConditions } = this;
     const len = havingConditions.length;
-    const condition = havingConditions.slice(1, len - 1).reduce((result, condition) => {
+    const combined = havingConditions.slice(1, len - 1).reduce((result, condition) => {
       return { type: 'op', name: 'and', args: [result, condition] };
     }, havingConditions[0]);
     this.havingConditions = [
-      { type: 'op', name: 'or', args: [condition, havingConditions[len - 1]] }
+      { type: 'op', name: 'or', args: [combined, havingConditions[len - 1]] }
     ];
     return this;
   }

--- a/test/integration/sqlite.test.js
+++ b/test/integration/sqlite.test.js
@@ -1,7 +1,8 @@
 'use strict';
 
+const assert = require('assert').strict;
 const path = require('path');
-const { connect, Bone } = require('../..');
+const { connect, raw, Bone } = require('../..');
 const { checkDefinitions } = require('./helpers');
 
 before(async function() {
@@ -51,5 +52,16 @@ describe('=> Table definitions (sqlite)', () => {
       id: { dataType: 'integer', primaryKey: true },
       public: { dataType: 'integer', primaryKey: false },
     });
+  });
+});
+
+describe('=> upsert', function () {
+  const Post = require('../models/post');
+
+  it('upsert', function() {
+    assert.equal(
+      new Post({ id: 1, title: 'New Post', createdAt: raw('CURRENT_TIMESTAMP()'), updatedAt: raw('CURRENT_TIMESTAMP()') }).upsert().toString(),
+      'INSERT INTO "articles" ("id", "title", "gmt_modified") VALUES (1, \'New Post\', CURRENT_TIMESTAMP()) ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "gmt_modified"=EXCLUDED."gmt_modified"'
+    );
   });
 });

--- a/test/integration/suite/basics.test.js
+++ b/test/integration/suite/basics.test.js
@@ -23,8 +23,7 @@ let stub;
 before(() => {
   stub = sinon.stub(logger, 'warn').callsFake((message) => {
     throw new Error(message);
-    }
-  );
+  });
 });
 
 after(() => {

--- a/test/start.sh
+++ b/test/start.sh
@@ -4,9 +4,12 @@ args=
 
 function run {
   file=$1;
+  if [ "${args[0]}" = "${file}" ]; then
+    args=("${args[@]:1}");
+  fi
   echo "";
-  echo "> DEBUG=leoric mocha --exit --timeout 5000 ${file} ${args}";
-  DEBUG=leoric mocha --exit --timeout 5000 ${file} ${args} || exit $?;
+  printf '"%s" ' "${args[@]}" | xargs echo "> DEBUG=leoric mocha --exit --timeout 5000 ${file}";
+  printf '"%s" ' "${args[@]}" | DEBUG=leoric xargs mocha --exit --timeout 5000 ${file} || exit $?;
 }
 
 ##
@@ -14,9 +17,7 @@ function run {
 function unit {
   # recursive glob nor available in bash 3
   # - https://unix.stackexchange.com/questions/49913/recursive-glob
-  for file in $(ls test/unit/{,drivers/,drivers/*/,adapters/}*.test.js); do
-    run ${file};
-  done
+  run "$(ls test/unit/{,drivers/,drivers/*/,adapters/}*.test.js)";
 }
 
 ##
@@ -27,15 +28,15 @@ function integration {
 
 case $1 in
   unit)
-    args="${@:2}"
+    args=("${@:2}")
     unit
     ;;
   integration)
-    args="${@:2}"
+    args=("${@:2}")
     integration
     ;;
   *.js)
-    args="${@:1}"
+    args=("${@:1}")
     run $1
     ;;
   *)

--- a/test/unit/adapters/sequelize.test.js
+++ b/test/unit/adapters/sequelize.test.js
@@ -7,7 +7,6 @@ const { Bone, connect, sequelize, DataTypes } = require('../../..');
 const { Hint } = require('../../../src/hint');
 const { logger } = require('../../../src/utils');
 
-
 const userAttributes = {
   id: DataTypes.BIGINT,
   gmt_create: DataTypes.DATE,

--- a/test/unit/bone.test.js
+++ b/test/unit/bone.test.js
@@ -7,6 +7,7 @@ const { BIGINT, STRING, DATE } = DataTypes;
 
 describe('=> Bone', function() {
   before(async function() {
+    Bone.driver = null;
     await connect({
       port: process.env.MYSQL_PORT,
       user: 'root',

--- a/test/unit/connect.test.js
+++ b/test/unit/connect.test.js
@@ -37,6 +37,22 @@ describe('connect', function() {
     assert.equal(Bone.driver, null);
   });
 
+  it('connect with custom Bone', async function() {
+    class Spine extends Bone {}
+    class Book extends Spine {}
+    await connect({
+      port: process.env.MYSQL_PORT,
+      user: 'root',
+      database: 'leoric',
+      Bone: Spine,
+      models: [ Book ],
+    });
+    assert.equal(Bone.driver, null);
+    assert.equal(Book.driver, Spine.driver);
+    assert.ok(Spine.driver);
+    assert.ok(Book.synchronized);
+  });
+
   it('connect models passed in opts.models (init with primaryKey)', async function() {
     const { STRING, BIGINT } = DataTypes;
     class Book extends Bone {
@@ -78,7 +94,7 @@ describe('connect', function() {
   });
 
   it('initialize model attributes if not defined in model itself', async () => {
-    const Book = require('../models/book');
+    class Book extends Bone {}
     await connect({
       port: process.env.MYSQL_PORT,
       user: 'root',

--- a/test/unit/drivers/abstract/spellbook.test.js
+++ b/test/unit/drivers/abstract/spellbook.test.js
@@ -13,6 +13,7 @@ describe('=> Spellbook', function() {
   }
 
   before(async function() {
+    Bone.driver = null;
     await connect({
       models: [ User, Post ],
       database: 'leoric',

--- a/test/unit/hint.test.js
+++ b/test/unit/hint.test.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const assert = require('assert').strict;
-const path = require('path');
 
-const { connect } = require('../..');
-const Post = require('../models/post');
+const { connect, Bone } = require('../..');
 
 const { Hint, IndexHint, INDEX_HINT_TYPE, INDEX_HINT_SCOPE } = require('../../src/hint');
 
@@ -49,9 +47,14 @@ describe('IndexHint', () => {
 });
 
 describe('MySQL', async () => {
+  class Post extends Bone {
+    static table = 'articles'
+  }
+
   before(async function() {
+    Bone.driver = null;
     await connect({
-      models: path.resolve(__dirname, '../models'),
+      models: [ Post ],
       database: 'leoric',
       user: 'root',
       port: process.env.MYSQL_PORT,

--- a/test/unit/hooks.test.js
+++ b/test/unit/hooks.test.js
@@ -63,6 +63,7 @@ describe('hooks', function() {
     });
 
     beforeEach(async () => {
+      Bone.driver = null;
       await connect({
         port: process.env.MYSQL_PORT,
         user: 'root',

--- a/test/unit/realm.test.js
+++ b/test/unit/realm.test.js
@@ -53,6 +53,14 @@ describe('=> Realm', () => {
     assert.ok(typeof Spine.prototype.setDataValue === 'function');
   });
 
+  it('should accept opts.Bone if it is subclass of Bone', async function() {
+    class Spine extends Bone {}
+    const realm = new Realm({ Bone: Spine });
+    assert.ok(realm.Bone);
+    assert.notEqual(realm.Bone, Bone);
+    assert.equal(realm.Bone, Spine);
+  });
+
   it('should rename opts.db to opts.database', async () => {
     const realm = new Realm({ db: 'leoric' });
     assert.equal(realm.options.database, 'leoric');

--- a/test/unit/spell.test.js
+++ b/test/unit/spell.test.js
@@ -1,45 +1,49 @@
 'use strict';
 
 const assert = require('assert').strict;
-const path = require('path');
 
-const { connect, Bone } = require('../..');
-const Post = require('../models/post');
-const TagMap = require('../models/tagMap');
-const Comment = require('../models/comment');
-const Book = require('../models/book');
-const User = require('../models/user');
-const Realm = require('../..');
+const { connect, raw, Bone } = require('../..');
 
-before(async function() {
-  await connect({
-    models: path.resolve(__dirname, '../models'),
-    database: 'leoric',
-    user: 'root',
-    port: process.env.MYSQL_PORT,
-  });
-});
+class Post extends Bone {
+  static table = 'articles'
+  static initialize() {
+    this.hasOne('attachment', { foreignKey: 'articleId' });
+  }
+}
+class TagMap extends Bone {}
+class Comment extends Bone {}
+class Book extends Bone {}
+class User extends Bone {}
+class Attachment extends Bone {}
 
 describe('=> Spell', function() {
+  before(async function() {
+    Bone.driver = null;
+    await connect({
+      models: [ Post, TagMap, Comment, Book, User, Attachment ],
+      database: 'leoric',
+      user: 'root',
+      port: process.env.MYSQL_PORT,
+    });
+  });
+
   it('rejects query if not connected yet', async () => {
     class Note extends Bone {};
     await assert.rejects(async () => await Note.all);
   });
 
   it('supports error convention with nodeify', async () => {
-    const result = await new Promise((resolve, reject) => {
+    const post = await new Promise((resolve, reject) => {
       Post.create({ title: 'Gettysburg Address' }).nodeify((err, result) => {
         if (err) reject(err);
         else resolve(result);
       });
     });
-    assert.ok(result instanceof Post);
-    assert.ok(result.id);
-    assert.equal(result.title, 'Gettysburg Address');
+    assert.ok(post instanceof Post);
+    assert.ok(post.id);
+    assert.equal(post.title, 'Gettysburg Address');
   });
-});
 
-describe('=> Insert', function() {
   it('insert', function() {
     const date = new Date(2017, 11, 12);
     assert.equal(
@@ -55,9 +59,7 @@ describe('=> Insert', function() {
       "INSERT INTO `articles` (`id`, `title`, `gmt_modified`) VALUES (1, 'New Post', '2017-12-12 00:00:00.000') ON DUPLICATE KEY UPDATE `id` = LAST_INSERT_ID(`id`), `id`=VALUES(`id`), `title`=VALUES(`title`), `gmt_modified`=VALUES(`gmt_modified`)"
     );
   });
-});
 
-describe('=> Select', function() {
   it('where object condition', function() {
     assert.equal(
       Post.where({ title: { $like: '%Post%' } }).toString(),
@@ -472,9 +474,7 @@ describe('=> Select', function() {
       'SELECT * FROM `articles` WHERE `gmt_deleted` IS NULL ORDER BY `id`, `gmt_created` DESC'
     );
   });
-});
 
-describe('=> Update', () => {
   it('increment', () => {
     assert.equal(
       Book.where({ isbn: 9787550616950 }).increment('price').toString(),
@@ -488,10 +488,8 @@ describe('=> Update', () => {
       'UPDATE `books` SET `price` = `price` - 1 WHERE `isbn` = 9787550616950 AND `gmt_deleted` IS NULL'
     );
   });
-});
 
-describe('=> Delete', () => {
-  it('where object condition', function() {
+  it('delete where object condition', function() {
     const sqlString = Post.remove({ title: { $like: '%Post%' } }).toString();
     assert(/UPDATE `articles` SET `gmt_deleted` = '[\s\S]*' WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL$/.test(sqlString));
   });
@@ -501,38 +499,36 @@ describe('=> Delete', () => {
     assert.equal(sqlString, "DELETE FROM `articles` WHERE `title` LIKE '%Post%'");
   });
 
-  it('set deletedAt', function() {
+  it('soft delete with custom timestamp', function() {
     const sqlString = Post.remove({ title: { $like: '%Post%' }, deletedAt: new Date() }).toString();
     assert(/UPDATE `articles` SET `gmt_deleted` = '[\s\S]*' WHERE `title` LIKE '%Post%' AND `gmt_deleted` = '[\s\S]*'$/.test(sqlString));
   });
-});
 
-describe('=> raw sql', () => {
-  it('update', function() {
+  it('update with raw sql', function() {
     assert.equal(
-      User.update({ id: 1 }, { level: Realm.raw('level + 1') }).toString(),
+      User.update({ id: 1 }, { level: raw('level + 1') }).toString(),
       'UPDATE `users` SET `level` = level + 1 WHERE `id` = 1'
     );
 
     assert.equal(
-      User.update({ id: 1 }, { nickname: Realm.raw("replace(nickname, 'gta', 'mhw')") }).toString(),
+      User.update({ id: 1 }, { nickname: raw("replace(nickname, 'gta', 'mhw')") }).toString(),
       "UPDATE `users` SET `nickname` = replace(nickname, 'gta', 'mhw') WHERE `id` = 1"
     );
 
     assert.equal(
-      User.update({ id: 1 }, { nickname: Realm.raw("replace(nickname, 'gta', 'mhw')") }).toString(),
+      User.update({ id: 1 }, { nickname: raw("replace(nickname, 'gta', 'mhw')") }).toString(),
       "UPDATE `users` SET `nickname` = replace(nickname, 'gta', 'mhw') WHERE `id` = 1"
     );
 
     assert.equal(
-      User.update({ id: 1 }, { nickname: Realm.raw("replace(nickname, 'gta', 'mhw')"), level: Realm.raw('level + 1') }).toString(),
+      User.update({ id: 1 }, { nickname: raw("replace(nickname, 'gta', 'mhw')"), level: raw('level + 1') }).toString(),
       "UPDATE `users` SET `nickname` = replace(nickname, 'gta', 'mhw'), `level` = level + 1 WHERE `id` = 1"
     );
   });
 
-  it('create', function() {
+  it('create with raw sql', function() {
     assert.equal(
-      Post.create({ title: 'New Post', createdAt: Realm.raw('CURRENT_TIMESTAMP()'), updatedAt: Realm.raw('CURRENT_TIMESTAMP()') }).toString(),
+      Post.create({ title: 'New Post', createdAt: raw('CURRENT_TIMESTAMP()'), updatedAt: raw('CURRENT_TIMESTAMP()') }).toString(),
       "INSERT INTO `articles` (`title`, `gmt_create`, `gmt_modified`) VALUES ('New Post', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP())"
     );
   });
@@ -541,7 +537,7 @@ describe('=> raw sql', () => {
     assert.equal(
       Post.where({
         author_id: {
-          $in: Realm.raw('(SELECT id FROM `users` WHERE level > 10 ORDER BY rand())')
+          $in: raw('(SELECT id FROM `users` WHERE level > 10 ORDER BY rand())')
         }
       }).toString(),
       'SELECT * FROM `articles` WHERE `author_id` IN (SELECT id FROM `users` WHERE level > 10 ORDER BY rand()) AND `gmt_deleted` IS NULL'
@@ -549,7 +545,7 @@ describe('=> raw sql', () => {
 
     assert.equal(
       Post.where({
-        author_id: Realm.raw('(SELECT id FROM `users` WHERE level > 10 ORDER BY rand() LIMIT 1)')
+        author_id: raw('(SELECT id FROM `users` WHERE level > 10 ORDER BY rand() LIMIT 1)')
       }).toString(),
       'SELECT * FROM `articles` WHERE `author_id` = (SELECT id FROM `users` WHERE level > 10 ORDER BY rand() LIMIT 1) AND `gmt_deleted` IS NULL'
     );
@@ -557,105 +553,35 @@ describe('=> raw sql', () => {
     assert.equal(
       Post.where({
         author_id: {
-          $gt: Realm.raw('(SELECT id FROM `users` WHERE level > 10 ORDER BY rand() LIMIT 1)')
+          $gt: raw('(SELECT id FROM `users` WHERE level > 10 ORDER BY rand() LIMIT 1)')
         }
       }).toString(),
       'SELECT * FROM `articles` WHERE `author_id` > (SELECT id FROM `users` WHERE level > 10 ORDER BY rand() LIMIT 1) AND `gmt_deleted` IS NULL'
     );
   });
 
-  it('order', function() {
+  it('order with raw sql', function() {
     assert.equal(
-      Post.order(Realm.raw("find_in_set(id, '1,2,3')")).toString(),
+      Post.order(raw("find_in_set(id, '1,2,3')")).toString(),
       "SELECT * FROM `articles` WHERE `gmt_deleted` IS NULL ORDER BY find_in_set(id, '1,2,3')"
     );
     assert.equal(
-      User.order(Realm.raw('rand()')).toString(),
+      User.order(raw('rand()')).toString(),
       'SELECT * FROM `users` ORDER BY rand()'
     );
   });
 
-  it('delete', function () {
+  it('delete with raw sql', function () {
     assert.equal(
-      User.remove({ deletedAt: Realm.raw('CURRENT_TIMESTAMP()') }).toString(),
+      User.remove({ deletedAt: raw('CURRENT_TIMESTAMP()') }).toString(),
       'DELETE FROM `users` WHERE `deletedAt` = CURRENT_TIMESTAMP()'
     );
   });
 
-  describe('upsert', function () {
-
-    it('mysql upsert', function() {
-      assert.equal(
-        new Post({ id: 1, title: 'New Post', createdAt: Realm.raw('CURRENT_TIMESTAMP()'), updatedAt: Realm.raw('CURRENT_TIMESTAMP()') }).upsert().toString(),
-        "INSERT INTO `articles` (`id`, `title`, `gmt_modified`) VALUES (1, 'New Post', CURRENT_TIMESTAMP()) ON DUPLICATE KEY UPDATE `id` = LAST_INSERT_ID(`id`), `id`=VALUES(`id`), `title`=VALUES(`title`), `gmt_modified`=VALUES(`gmt_modified`)"
-      );
-    });
-
-    describe('postgres upsert', function () {
-      class MyPost extends Bone {
-        static get table() {
-          return 'articles';
-        }
-      }
-      before(async function() {
-        Bone.driver = null;
-        await connect({
-          dialect: 'postgres',
-          host: process.env.POSTGRES_HOST || '127.0.0.1',
-          port: process.env.POSTGRES_PORT,
-          user: process.env.POSTGRES_USER || '',
-          database: 'leoric',
-          models: [ MyPost ],
-          Bone: Bone,
-        });
-      });
-
-      it('upsert', function() {
-        assert.equal(
-          new MyPost({ id: 1, title: 'New Post', createdAt: Realm.raw('CURRENT_TIMESTAMP()'), updatedAt: Realm.raw('CURRENT_TIMESTAMP()') }).upsert().toString(),
-          'INSERT INTO "articles" ("id", "title", "gmt_modified") VALUES (1, \'New Post\', CURRENT_TIMESTAMP()) ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "gmt_modified"=EXCLUDED."gmt_modified" RETURNING "id"'
-        );
-      });
-
-      it('upsert returning multiple columns', function() {
-        assert.equal(
-          new MyPost({ id: 1, title: 'New Post', createdAt: Realm.raw('CURRENT_TIMESTAMP()'), updatedAt: Realm.raw('CURRENT_TIMESTAMP()') }).upsert({ returning: [ 'id', 'title' ] }).toString(),
-          'INSERT INTO "articles" ("id", "title", "gmt_modified") VALUES (1, \'New Post\', CURRENT_TIMESTAMP()) ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "gmt_modified"=EXCLUDED."gmt_modified" RETURNING "id", "title"'
-        );
-      });
-
-      after(() => {
-        Bone.driver = null;
-      });
-
-    });
-
-    describe('sqlite upsert', function () {
-      class MyPost extends Bone {
-        static get table() {
-          return 'articles';
-        }
-      }
-      before(async function() {
-        Bone.driver = null;
-        await connect({
-          dialect: 'sqlite',
-          database: '/tmp/leoric.sqlite3',
-          models: [ MyPost ],
-          Bone: Bone,
-        });
-      });
-
-      it('upsert', function() {
-        assert.equal(
-          new MyPost({ id: 1, title: 'New Post', createdAt: Realm.raw('CURRENT_TIMESTAMP()'), updatedAt: Realm.raw('CURRENT_TIMESTAMP()') }).upsert().toString(),
-          'INSERT INTO "articles" ("id", "title", "gmt_modified") VALUES (1, \'New Post\', CURRENT_TIMESTAMP()) ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "gmt_modified"=EXCLUDED."gmt_modified"'
-        );
-      });
-
-      after(() => {
-        Bone.driver = null;
-      });
-    });
+  it('upsert with raw sql', function () {
+    assert.equal(
+      new Post({ id: 1, title: 'New Post', createdAt: raw('CURRENT_TIMESTAMP()'), updatedAt: raw('CURRENT_TIMESTAMP()') }).upsert().toString(),
+      "INSERT INTO `articles` (`id`, `title`, `gmt_modified`) VALUES (1, 'New Post', CURRENT_TIMESTAMP()) ON DUPLICATE KEY UPDATE `id` = LAST_INSERT_ID(`id`), `id`=VALUES(`id`), `title`=VALUES(`title`), `gmt_modified`=VALUES(`gmt_modified`)"
+    );
   });
 });

--- a/test/unit/utils/string.test.js
+++ b/test/unit/utils/string.test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const assert = require('assert').strict;
+const { heresql } = require('../../../src/utils/string');
+
+describe('=> heresql', function() {
+  it('should accept function comment', function() {
+    assert.equal(heresql(function() {/*
+      SELECT 1,
+             2,
+             now()
+    */}), 'SELECT 1, 2, now()');
+  });
+
+  it('should accept template literal', function() {
+    assert.equal(heresql(`
+      SELECT 1,
+             2,
+             now()
+    `), 'SELECT 1, 2, now()');
+  });
+});

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -70,6 +70,7 @@ describe('validator', () => {
   User.init(attributes);
 
   before(async function() {
+    Bone.driver = null;
     await connect({
       models: [ User ],
       database: 'leoric',


### PR DESCRIPTION
...at least for test:unit, especially in following scenario:

```js
class Spine extends Bone {}
class Book extends Spine {}
await connect({ Bone: Spine });
```

which connects `Spine.driver` without polluting `Bone.driver`. Handy for test cases.