### PR TITLE
fix: validator call array arguments

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -107,8 +107,8 @@ function executeValidator(ctx, name, attribute, setValue) {
       }
       return;
     }
-    const callableArgs = [ String(value) ];
-    callableArgs.push(args);
+    let callableArgs = [ String(value) ];
+    callableArgs = callableArgs.concat(args);
     if (!validator.apply(ctx, callableArgs)) throw new LeoricValidateError(name, field, msg);
   }
 }

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -23,7 +23,7 @@ describe('validator', () => {
       allowNull: false,
       validate: {
         isNumeric: false,
-        notIn: [ 'Yhorm', 'Gwyn' ],
+        notIn: [ [ 'Yhorm', 'Gwyn' ] ],
         notContains: 'closePease',
       }
     },
@@ -40,7 +40,7 @@ describe('validator', () => {
       validate: {
         isNumeric: true,
         isIn: {
-          args: [ '1', '2' ],
+          args: [ [ '1', '2' ] ],
           msg: 'Error status',
         },
       }


### PR DESCRIPTION
```js

bone.define('User', {
   status: {
     type: STRING,
     validate: {
        isIn: {
          args: [ [ '1', '2' ] ], // not [ '1', '2' ]
          msg: 'Error status',
        },
     }
   }
})

```