### PR TITLE
fix: attribute.equals() check should ignore defaultValue

### DIFF
--- a/History.md
+++ b/History.md
@@ -74,7 +74,7 @@
 ==================
 
   * feat: support class static attributes and hooks (#131)
-  * fix: names defined in Bone.attributes should be always enumerable (#128)
+  * fix: names defined in Bone.attributes should always be enumerable (#128)
   * chore: add quality badge to readme (#129)
 
 1.5.2 / 2021-07-02

--- a/src/bone.js
+++ b/src/bone.js
@@ -943,7 +943,7 @@ class Bone {
       primaryKey,
       columns,
       attributeMap,
-      associations: [],
+      associations: {},
       tableAlias,
       synchronized: Object.keys(compare(attributes, columns)).length === 0,
     }));
@@ -1493,7 +1493,7 @@ class Bone {
 
     const { attributes, columns } = this;
 
-    if (Object.keys(columns).length === 0) {
+    if (columns.length === 0) {
       await driver.createTable(table, attributes);
     } else {
       await driver.alterTable(table, compare(attributes, columns));

--- a/src/drivers/abstract/attribute.js
+++ b/src/drivers/abstract/attribute.js
@@ -106,7 +106,7 @@ class Attribute {
 
   equals(targetAttribute) {
     if (!targetAttribute) return false;
-    const props = [ 'dataType', 'allowNull', 'defaultValue', 'primaryKey' ];
+    const props = [ 'dataType', 'allowNull', 'primaryKey' ];
     for (const prop of props) {
       // SQLite has default value as string even if data type is integer
       if (this[prop] != targetAttribute[prop]) {

--- a/src/drivers/sqlite/connection.js
+++ b/src/drivers/sqlite/connection.js
@@ -1,0 +1,82 @@
+'use strict';
+
+// SELECT users.id AS "users:id", ...
+// => [ { users: { id, ... } } ]
+function nest(rows, fields, spell) {
+  const { Model } = spell;
+  const { tableAlias } = Model;
+  const results = [];
+
+  for (const row of rows) {
+    const result = {};
+    const qualified = Object.keys(row).some(entry => entry.includes(':'));
+    for (const key in row) {
+      const parts = key.split(':');
+      const [qualifier, column] = qualified
+        ? (parts.length > 1 ? parts : ['', key])
+        : [Model.attributeMap.hasOwnProperty(key) ? tableAlias : '', key];
+      const obj = result[qualifier] || (result[qualifier] = {});
+      obj[column] = row[key];
+    }
+    results.push(result);
+  }
+
+  return { rows: results, fields };
+}
+
+class Connection {
+  constructor({ client, database, mode, pool }) {
+    const { Database, OPEN_READWRITE, OPEN_CREATE } = client;
+    if (mode == null) mode = OPEN_READWRITE | OPEN_CREATE;
+    this.database = new Database(database, mode);
+    this.pool = pool;
+  }
+
+  async query(query, values, spell) {
+    const { sql, nestTables } = query.sql ? query : { sql: query };
+
+    if (/^(?:pragma|select)/i.test(sql)) {
+      const result = await this.all(sql, values);
+      if (nestTables) return nest(result.rows, result.fields, spell);
+      return result;
+    }
+    return await this.run(sql, values);
+  }
+
+  all(sql, values) {
+    return new Promise((resolve, reject) => {
+      this.database.all(sql, values, (err, rows, fields) => {
+        if (err) reject(err);
+        else resolve({ rows, fields });
+      });
+    });
+  }
+
+  run(sql, values) {
+    return new Promise((resolve, reject) => {
+      this.database.run(sql, values, function Leoric_sqliteRun(err) {
+        if (err) reject(err);
+        else resolve({ insertId: this.lastID, affectedRows: this.changes });
+      });
+    });
+  }
+
+  release() {
+    this.pool.releaseConnection(this);
+  }
+
+  async end() {
+    const { connections } = this.pool;
+    const index = connections.indexOf(this);
+    if (index >= 0) connections.splice(index, 1);
+
+    return await new Promise((resolve, reject) => {
+      this.database.close(function(err) {
+        if (err) reject(err);
+        resolve();
+      });
+    });
+  }
+}
+
+module.exports = Connection;

--- a/src/drivers/sqlite/index.js
+++ b/src/drivers/sqlite/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const EventEmitter = require('events');
 const strftime = require('strftime');
 
 const AbstractDriver = require('../abstract');
@@ -9,130 +8,7 @@ const DataTypes = require('./data_types');
 const { escapeId, escape } = require('./sqlstring');
 const schema = require('./schema');
 const spellbook = require('./spellbook');
-
-// SELECT users.id AS "users:id", ...
-// => [ { users: { id, ... } } ]
-function nest(rows, fields, spell) {
-  const { Model } = spell;
-  const { tableAlias } = Model;
-  const results = [];
-
-  for (const row of rows) {
-    const result = {};
-    const qualified = Object.keys(row).some(entry => entry.includes(':'));
-    for (const key in row) {
-      const parts = key.split(':');
-      const [qualifier, column] = qualified
-        ? (parts.length > 1 ? parts : ['', key])
-        : [Model.attributeMap.hasOwnProperty(key) ? tableAlias : '', key];
-      const obj = result[qualifier] || (result[qualifier] = {});
-      obj[column] = row[key];
-    }
-    results.push(result);
-  }
-
-  return { rows: results, fields };
-}
-
-class Connection {
-  constructor({ client, database, mode, pool }) {
-    const { Database, OPEN_READWRITE, OPEN_CREATE } = client;
-    if (mode == null) mode = OPEN_READWRITE | OPEN_CREATE;
-    this.database = new Database(database, mode);
-    this.pool = pool;
-  }
-
-  async query(query, values, spell) {
-    const { sql, nestTables } = query.sql ? query : { sql: query };
-
-    if (/^(?:pragma|select)/i.test(sql)) {
-      const result = await this.all(sql, values);
-      if (nestTables) return nest(result.rows, result.fields, spell);
-      return result;
-    }
-    return await this.run(sql, values);
-  }
-
-  all(sql, values) {
-    return new Promise((resolve, reject) => {
-      this.database.all(sql, values, (err, rows, fields) => {
-        if (err) reject(err);
-        else resolve({ rows, fields });
-      });
-    });
-  }
-
-  run(sql, values) {
-    return new Promise((resolve, reject) => {
-      this.database.run(sql, values, function Leoric_sqliteRun(err) {
-        if (err) reject(err);
-        else resolve({ insertId: this.lastID, affectedRows: this.changes });
-      });
-    });
-  }
-
-  release() {
-    this.pool.releaseConnection(this);
-  }
-
-  async end() {
-    const { connections } = this.pool;
-    const index = connections.indexOf(this);
-    if (index >= 0) connections.splice(index, 1);
-
-    return await new Promise((resolve, reject) => {
-      this.database.close(function(err) {
-        if (err) reject(err);
-        resolve();
-      });
-    });
-  }
-}
-
-class Pool extends EventEmitter {
-  constructor(opts) {
-    super(opts);
-    this.options = {
-      connectionLimit: 10,
-      ...opts,
-      client: opts.client || 'sqlite3',
-    };
-    this.client = require(this.options.client);
-    this.connections = [];
-    this.queue = [];
-  }
-
-  async getConnection() {
-    const { connections, queue, client, options } = this;
-    for (const connection of connections) {
-      if (connection.idle) {
-        connection.idle = false;
-        this.emit('acquire', connection);
-        return connection;
-      }
-    }
-    if (connections.length < options.connectionLimit) {
-      const connection = new Connection({ ...options, client, pool: this });
-      connections.push(connection);
-      this.emit('acquire', connection);
-      return connection;
-    }
-    await new Promise(resolve => queue.push(resolve));
-    return await this.getConnection();
-  }
-
-  releaseConnection(connection) {
-    connection.idle = true;
-    this.emit('release', connection);
-
-    const { queue } = this;
-    while (queue.length > 0) {
-      const task = queue.shift();
-      task();
-    }
-  }
-}
-
+const Pool = require('./pool');
 class SqliteDriver extends AbstractDriver {
   constructor(opts = {}) {
     super(opts);

--- a/src/drivers/sqlite/pool.js
+++ b/src/drivers/sqlite/pool.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const EventEmitter = require('events');
+const Connection = require('./connection');
+
+class Pool extends EventEmitter {
+  constructor(opts) {
+    super(opts);
+    this.options = {
+      connectionLimit: 10,
+      ...opts,
+      client: opts.client || 'sqlite3',
+    };
+    this.client = require(this.options.client);
+    this.connections = [];
+    this.queue = [];
+  }
+
+  async getConnection() {
+    const { connections, queue, client, options } = this;
+    for (const connection of connections) {
+      if (connection.idle) {
+        connection.idle = false;
+        this.emit('acquire', connection);
+        return connection;
+      }
+    }
+    if (connections.length < options.connectionLimit) {
+      const connection = new Connection({ ...options, client, pool: this });
+      connections.push(connection);
+      this.emit('connection', connection);
+      this.emit('acquire', connection);
+      return connection;
+    }
+    await new Promise(resolve => queue.push(resolve));
+    return await this.getConnection();
+  }
+
+  releaseConnection(connection) {
+    connection.idle = true;
+    this.emit('release', connection);
+
+    const { queue } = this;
+    while (queue.length > 0) {
+      const task = queue.shift();
+      task();
+    }
+  }
+}
+
+module.exports = Pool;

--- a/src/validator.js
+++ b/src/validator.js
@@ -69,7 +69,7 @@ function executeValidator(ctx, name, attribute, setValue) {
   const { name: field, validate, defaultValue } = attribute;
   const validateArgs = validate[name];
 
-  const value = setValue != null? setValue : defaultValue;
+  const value = setValue != null ? setValue : defaultValue;
   if (typeof validateArgs === 'function') {
     let needToRevert = false;
     let originValue;
@@ -103,7 +103,7 @@ function executeValidator(ctx, name, attribute, setValue) {
 
     if (['true', 'false'].indexOf(String(validateArgs)) >= 0) {
       if (validator.call(ctx, value == null ? value : String(value)) !== args) {
-        throw new LeoricValidateError(name, field, msg, !validateArgs? validateArgs : undefined);
+        throw new LeoricValidateError(name, field, msg, !validateArgs ? validateArgs : undefined);
       }
       return;
     }

--- a/test/unit/drivers/sqlite/pool.test.js
+++ b/test/unit/drivers/sqlite/pool.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const assert = require('assert').strict;
+const Pool = require('../../../../src/drivers/sqlite/pool');
+
+describe('=> SQLite driver.pool', function() {
+  it('should emit connection', async function() {
+    const pool = new Pool({
+      database: '/tmp/leoric.sqlite3',
+    });
+    let result;
+    pool.on('connection', function(connection) {
+      result = connection;
+    });
+    assert.equal(await pool.getConnection(), result);
+  });
+});


### PR DESCRIPTION
`attribute.defaultValue` currently have two mixed responsibility:
- the default value set in table schema
- the default value to be set when saving records via model methods