### PR TITLE
fix: turn on long stack trace of sqlite driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@babel/core": "^7.14.6",
     "@babel/eslint-parser": "^7.14.7",
     "@cara/minami": "^1.2.3",
+    "@journeyapps/sqlcipher": "^5.2.0",
     "dayjs": "^1.10.3",
     "eslint": "^7.20.0",
     "expect.js": "^0.3.1",

--- a/src/drivers/sqlite/connection.js
+++ b/src/drivers/sqlite/connection.js
@@ -45,18 +45,24 @@ class Connection {
 
   all(sql, values) {
     return new Promise((resolve, reject) => {
-      this.database.all(sql, values, (err, rows, fields) => {
-        if (err) reject(err);
-        else resolve({ rows, fields });
+      this.database.all(sql, values, function Leoric_all(err, rows, fields) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({ rows, fields });
+        }
       });
     });
   }
 
   run(sql, values) {
     return new Promise((resolve, reject) => {
-      this.database.run(sql, values, function Leoric_sqliteRun(err) {
-        if (err) reject(err);
-        else resolve({ insertId: this.lastID, affectedRows: this.changes });
+      this.database.run(sql, values, function Leoric_run(err) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({ insertId: this.lastID, affectedRows: this.changes });
+        }
       });
     });
   }
@@ -71,9 +77,12 @@ class Connection {
     if (index >= 0) connections.splice(index, 1);
 
     return await new Promise((resolve, reject) => {
-      this.database.close(function(err) {
-        if (err) reject(err);
-        resolve();
+      this.database.close(function Leoric_end(err) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
       });
     });
   }

--- a/src/drivers/sqlite/pool.js
+++ b/src/drivers/sqlite/pool.js
@@ -11,7 +11,13 @@ class Pool extends EventEmitter {
       ...opts,
       client: opts.client || 'sqlite3',
     };
-    this.client = require(this.options.client);
+
+    const client = require(this.options.client);
+    // Turn on stack trace capturing otherwise the output is useless
+    // - https://github.com/mapbox/node-sqlite3/wiki/Debugging
+    client.verbose();
+
+    this.client = client;
     this.connections = [];
     this.queue = [];
   }

--- a/test/integration/sqlcipher.test.js
+++ b/test/integration/sqlcipher.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const fs = require('fs').promises;
+const path = require('path');
+const sqlcipher = require('@journeyapps/sqlcipher');
+const Realm = require('../..');
+
+before(async function() {
+  const plaintext = '/tmp/leoric.sqlite3';
+  const encrypted = '/tmp/leoric-encrypted.sqlite3';
+
+  sqlcipher.verbose();
+  const { Database, OPEN_READWRITE, OPEN_CREATE } = sqlcipher;
+  const database = new Database(plaintext, OPEN_READWRITE | OPEN_CREATE);
+  await fs.unlink(encrypted).catch(() => {/* ignored */});
+  await new Promise((resolve, reject) => {
+    database.serialize(function() {
+      database.run(`ATTACH DATABASE '${encrypted}' AS encrypted KEY 'Accio!'`);
+      database.run(`SELECT sqlcipher_export('encrypted')`);
+      database.run(`DETACH DATABASE encrypted`, function(err) {
+        if (err) reject(err);
+        resolve();
+      });
+    });
+  });
+
+  const realm = new Realm({
+    dialect: 'sqlite',
+    database: encrypted,
+    client: '@journeyapps/sqlcipher',
+    models: path.resolve(__dirname, '../models'),
+  });
+
+  realm.driver.pool.on('connection', function(connection) {
+    connection.query('PRAGMA key = "Accio!"');
+  });
+
+  await realm.connect();
+});
+
+require('./suite/index.test');

--- a/test/integration/sqlite.test.js
+++ b/test/integration/sqlite.test.js
@@ -55,7 +55,7 @@ describe('=> Table definitions (sqlite)', () => {
   });
 });
 
-describe('=> upsert', function () {
+describe('=> upsert (sqlite)', function () {
   const Post = require('../models/post');
 
   it('upsert', function() {

--- a/test/integration/suite/migrations.test.js
+++ b/test/integration/suite/migrations.test.js
@@ -43,6 +43,11 @@ describe('=> Migrations', async () => {
   before(() => {
     // use existing options, such as test/integration/test.mysql.js
     realm = new Realm({ ...Bone.options, migrations });
+    if (/sqlcipher/.test(realm.options.client || '')) {
+      realm.driver.pool.on('connection', function(connection) {
+        connection.query('PRAGMA key = "Accio!"');
+      });
+    }
   });
 
   beforeEach(async () => {

--- a/test/unit/drivers/sqlite/index.test.js
+++ b/test/unit/drivers/sqlite/index.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert').strict;
+const path = require('path');
 const strftime = require('strftime');
 
 const { heresql } = require('../../../../src/utils/string');
@@ -173,6 +174,16 @@ describe('=> SQLite driver.query()', () => {
       ]
     } = await driver.query('SELECT is_private FROM notes');
     assert.equal(is_private, 1);
+  });
+
+  it('should support async stack trace', async function() {
+    await assert.rejects(async function() {
+      await driver.query('SELECT * FROM missing');
+    }, function(err) {
+      assert(err instanceof Error);
+      assert(/SQLITE_ERROR: no such table/i.test(err.message));
+      return err.stack.includes(path.basename(__filename));
+    });
   });
 });
 


### PR DESCRIPTION
added integration test with @journeyapps/sqlcipher client

before:
```js
  1) => SQLite driver.query()
       should support async stack trace:
     Error: SQLITE_ERROR: no such table: missing
```

after:
```js
  1) => SQLite driver.query()
       should support async stack trace:
     Error: SQLITE_ERROR: no such table: missing
  --> in Database#all('SELECT * FROM missing', undefined, [Function: Leoric_all])
      at /Users/nil/Projects/cyjake/leoric/src/drivers/sqlite/connection.js:48:21
      at new Promise (<anonymous>)
      at Connection.all (src/drivers/sqlite/connection.js:47:12)
      at Connection.query (src/drivers/sqlite/connection.js:39:33)
      at SqliteDriver.query (src/drivers/sqlite/index.js:46:33)
      at async Context.<anonymous> (test/unit/drivers/sqlite/index.test.js:181:7)
```