### PR TITLE
refactor: object condition parsing and expression formatting

### DIFF
--- a/src/expr_formatter.js
+++ b/src/expr_formatter.js
@@ -1,0 +1,192 @@
+'use strict';
+
+const { precedes, walkExpr } = require('./expr');
+
+/**
+ * Find model by qualifiers.
+ * @example
+ * findModel(spell, ['comments'])
+ * findModel(spell)
+ *
+ * @param {Spell} spell
+ * @param {string[]} qualifiers
+ */
+ function findModel(spell, qualifiers) {
+  const qualifier = qualifiers && qualifiers[0];
+  const Model = qualifier && qualifier != spell.Model.tableAlias
+    ? (spell.joins.hasOwnProperty(qualifier) ? spell.joins[qualifier].Model : null)
+    : spell.Model;
+  if (!Model) throw new Error(`Unabled to find model ${qualifiers}`);
+  return Model;
+}
+
+/**
+ * Format identifiers into escaped string with qualifiers.
+ * @param {Spell}  spell
+ * @param {Object} ast
+ */
+function formatIdentifier(spell, ast) {
+  const { value, qualifiers } = ast;
+  const Model = findModel(spell, qualifiers);
+  const column = Model.unalias(value);
+  const { escapeId } = spell.Model.driver;
+
+  if (qualifiers && qualifiers.length > 0) {
+    return `${qualifiers.map(escapeId).join('.')}.${escapeId(column)}`;
+  }
+
+  return escapeId(column);
+}
+
+const extractFieldNames = ['year', 'month', 'day'];
+
+function formatFuncExpr(spell, ast) {
+  const { name, args } = ast;
+  const { type } = spell.Model.driver;
+
+  // https://www.postgresql.org/docs/9.1/static/functions-datetime.html
+  if (type === 'postgres' && extractFieldNames.includes(name)) {
+    return `EXTRACT(${name.toUpperCase()} FROM ${args.map(arg => formatExpr(spell, arg)).join(', ')})`;
+  }
+
+  return `${name.toUpperCase()}(${args.map(arg => formatExpr(spell, arg)).join(', ')})`;
+}
+
+function formatLiteral(spell, ast) {
+  const { value } = ast;
+
+  if (value == null) return 'NULL';
+
+  if (Array.isArray(value)) {
+    if (value.length) return `(${value.map(() => '?').join(', ')})`;
+    return '(NULL)';
+  }
+
+  return '?';
+}
+
+/**
+ * Format the abstract syntax tree of an expression into escaped string.
+ * @param {Spell}  spell
+ * @param {Object} ast
+ */
+function formatExpr(spell, ast) {
+  const { type, name, value, args } = ast;
+  switch (type) {
+    case 'literal':
+      return formatLiteral(spell, ast);
+    case 'subquery':
+      return `(${value.toSqlString()})`;
+    case 'wildcard':
+      return '*';
+    case 'alias':
+      return `${formatExpr(spell, args[0])} AS ${formatIdentifier(spell, ast)}`;
+    case 'mod':
+      return `${name.to.toUpperCase()} ${formatExpr(spell, args[0])}`;
+    case 'id':
+      return formatIdentifier(spell, ast);
+    case 'op':
+      return formatOpExpr(spell, ast);
+    case 'func':
+      return formatFuncExpr(spell, ast);
+    case 'raw':
+      // return value directly
+      return value;
+    default:
+      throw new Error(`Unexpected type ${type}`);
+  }
+}
+
+/**
+ * Check if current token is logical operator or not, e.g. `AND`/`NOT`/`OR`.
+ * @param {Object} ast
+ */
+function isLogicalOp({ type, name }) {
+  return type == 'op' && ['and', 'not', 'or'].includes(name);
+}
+
+/**
+ * Format `{ type: 'op' }` expressions into escaped string.
+ * @param {Spell}  spell
+ * @param {Object} ast
+ */
+function formatOpExpr(spell, ast) {
+  const { name, args } = ast;
+  const params = args.map(arg => {
+    return isLogicalOp(ast) && isLogicalOp(arg) && precedes(name, arg.name) < 0
+      ? `(${formatExpr(spell, arg)})`
+      : formatExpr(spell, arg);
+  });
+
+  if (name == 'between' || name == 'not between') {
+    return `${params[0]} ${name.toUpperCase()} ${params[1]} AND ${params[2]}`;
+  }
+
+  if (name == 'not') return `NOT ${params[0]}`;
+
+  if ('!~-'.includes(name) && params.length == 1) return `${name} ${params[0]}`;
+
+  if (args[1].type == 'literal' && args[1].value == null && !isLogicalOp(ast)) {
+    if (!['=', '!='].includes(name)) {
+      throw new Error(`Invalid operator ${name} against null`);
+    }
+    return `${params[0]} ${name === '=' ? 'IS' : 'IS NOT'} NULL`;
+  }
+
+  // IN (1, 2, 3)
+  // IN (SELECT user_id FROM group_users)
+  if ((args[1].type == 'literal' && Array.isArray(args[1].value)) || args[1].type == 'subquery') {
+    let op = name;
+    if (name == '=') {
+      op = 'in';
+    } else if (name == '!=') {
+      op = 'not in';
+    }
+    if (!['in', 'not in'].includes(op)) {
+      throw new Error(`Invalid operator ${name} against ${args[1].value}`);
+    }
+    return `${params[0]} ${op.toUpperCase()} ${params[1]}`;
+  }
+
+  if (params[1] !== '') {
+    return `${params[0]} ${name.toUpperCase()} ${params[1]}`;
+  }
+}
+
+/**
+ * Format an array of conditions into an expression. Conditions will be joined with `AND`.
+ * @param {Object[]} conditions - An array of parsed where/having/on conditions
+ */
+function formatConditions(spell, conditions) {
+  return conditions
+    .map(condition => {
+      return isLogicalOp(condition) && condition.name == 'or' && conditions.length > 1
+        ? `(${formatExpr(spell, condition)})`
+        : formatExpr(spell, condition);
+    })
+    // filter empty condition
+    .filter((condition) => !!condition)
+    .join(' AND ');
+}
+
+/**
+ * The `... IS NULL` predicate is not parameterizable.
+ * - https://github.com/brianc/node-postgres/issues/1751
+ * @param {Array} values the collected values
+ * @param {Object} ast the abstract syntax tree
+ * @returns {Array} values
+ */
+function collectLiteral(values, ast) {
+  walkExpr(ast, ({ type, value }) => {
+    if (type == 'literal' && value != null) {
+      if (Array.isArray(value)) {
+        values.push(...value);
+      } else {
+        values.push(value);
+      }
+    }
+  });
+  return values;
+}
+
+module.exports = { formatExpr, formatConditions, collectLiteral };

--- a/src/query_object.js
+++ b/src/query_object.js
@@ -1,0 +1,228 @@
+'use strict';
+
+const util = require('util');
+const { isPlainObject } = require('./utils');
+const { parseExpr } = require('./expr');
+// deferred to break cyclic dependencies
+let Spell;
+
+const OPERATOR_MAP = {
+  $between: 'between',
+  $eq: '=',
+  $gt: '>',
+  $gte: '>=',
+  $in: 'in',
+  $like: 'like',
+  $lt: '<',
+  $lte: '<=',
+  $ne: '!=',
+  $nin: 'not in',
+  $notBetween: 'not between',
+  $notLike: 'not like',
+  $notIn: 'not in'
+};
+
+/**
+ * Parse object values as literal or subquery
+ * @param {Object} value
+ * @returns {Array<Object>}
+ */
+function parseValue(value) {
+  if (value instanceof Spell) return { type: 'subquery', value };
+  if (value && value.__raw) return { type: 'raw', value: value.value };
+  return parseExpr('?', value);
+}
+
+/**
+ * Check if object condition is an operator condition, such as `{ $gte: 100, $lt: 200 }`.
+ * @param {Object} condition
+ * @returns {boolean}
+ */
+function isOperatorCondition(condition) {
+  if (!isPlainObject(condition)) return false;
+  for (const $op in condition) {
+    if (OPERATOR_MAP.hasOwnProperty($op)) return true;
+  }
+  return false;
+}
+
+function merge(conditions, operator = 'and') {
+  return conditions.reduce((res, condition) => {
+    if (!res) return condition;
+    return { type: 'op', name: operator, args: [ res, condition ] };
+  }, null);
+}
+
+/**
+ * parse operator condition into expression ast
+ * @example
+ * parseOperator('id', { $gt: 0, $lt: 999999 });
+ * // => { type: 'op', name: 'and', args: [ ... ]}
+ * @param {string} name
+ * @param {Object} condition
+ * @returns {Object}
+ */
+function parseOperator(name, condition) {
+  const result = [];
+
+  for (const $op in condition) {
+    const operator = $op === '$not' ? OPERATOR_MAP.$ne : OPERATOR_MAP[$op];
+    if (!operator) {
+      throw new Error(util.format('unexpected operator in condition %s', condition));
+    }
+    const args = [ parseExpr(name) ];
+    const val = condition[$op];
+
+    if (operator == 'between' || operator == 'not between') {
+      args.push(parseValue(val[0]), parseValue(val[1]));
+    } else {
+      args.push(parseValue(val));
+    }
+
+    result.push({ type: 'op', name: operator, args });
+  }
+
+  return merge(result);
+}
+
+const LOGICAL_OPERATOR_MAP = {
+  $and: 'and',
+  $or: 'or',
+  $not: 'not',
+};
+
+/**
+ * determin if operator is logical operator
+ * @param {string} operator lowercased operator
+ * @returns {boolean}
+ */
+function isLogicalOperator(operator) {
+  return LOGICAL_OPERATOR_MAP.hasOwnProperty(operator);
+}
+
+/**
+ * determine if query object is logical condition
+ * @param {Object} condition query object
+ * @returns {boolean}
+ */
+function isLogicalCondition(condition) {
+  for (const name in condition) {
+    if (LOGICAL_OPERATOR_MAP.hasOwnProperty(name)) return true;
+  }
+  return false;
+}
+
+/**
+ * parse logical objects that is already in tree-like structure
+ * @example
+ * { $or: { title: 'Leah', content: 'Diablo' } }
+ * { $or: [ { title: 'Leah' }, { content: 'Diablo' } ] }
+ * { $not: [ { title: 'Leah' }, { title: { $like: '%jjj' }} ] }
+ * @param {string} $op logical operators, such as `$or`, `$and`, and `$not`.
+ * @param {Object|Object[]} value logical operands
+ */
+function parseLogicalOperator($op, value) {
+  const operator = LOGICAL_OPERATOR_MAP[$op];
+
+  if (isPlainObject(value)) {
+    value = Object.keys(value).reduce((res, key) => {
+      return res.concat({ [key]: value[key] });
+    }, []);
+  }
+
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`unexpected logical operator value ${value}`);
+  }
+
+  const result = merge(value.map(entry => merge(parseObject(entry))), operator);
+  const { args } = result;
+
+  // { title: { $or: [ 'Leah' ] } }
+  // { title: { $and: { $ne: 'Leah' } } }
+  if (args.length === 1 && operator !== 'not') return args[0];
+
+  // { title: { $not: [ { $like: '%foo%' }, { $like: '%bar%' } ] } }
+  if (args.length > 1 && operator === 'not') {
+    return { type: 'op', name: operator, args: [ merge(args) ] };
+  }
+
+  return result;
+}
+
+/**
+ * parse logical objects that have column name lifted upper level
+ * @example
+ * { foo: { $not: { $gt: '2021-01-01', $lte: '2021-12-31' } } }
+ * { foo: { $not: [ '2021-09-30', { $gte: '2021-10-07' } ] } }
+ * { foo: { $not: [ 'Leah', 'Nephalem' ] } }
+ * @param {string} name column name
+ * @param {Object} condition logical query objects
+ * @returns {Object}
+ */
+function parseNamedLogicalOperator(name, condition) {
+  for (const $op of Object.keys(condition)) {
+    const operator = LOGICAL_OPERATOR_MAP[$op];
+    const value = condition[$op];
+    // { $not: [ 1, 2, 3 ] }
+    if (operator === 'not' && Array.isArray(value) && !value.some(isPlainObject)) {
+      return parseOperator(name, { $notIn: value });
+    }
+    const args = [].concat(value).map(entry => ({ [name]: entry }));
+    return parseLogicalOperator($op, args);
+  }
+}
+
+/**
+ * Parse query objects, which is a complete madness because the operator orders vary. The result would be normalized spell ast. See {@link module:src/query_object~OPERATOR_MAP} and {@link module:src/query_object~LOGICAL_OPERATOR_MAP} for supported `$op`s.
+ * @example
+ * { foo: null }
+ * { foo: { $gt: new Date(2012, 4, 15) } }
+ * { foo: { $between: [1, 10] } }
+ * { foo: { $or: [ 'Leah', { $like: '%Leah%' } ] } }
+ * { foo: [ 1, 2, 3 ] }
+ * { foo: { $not: { $gt: '2021-01-01', $lte: '2021-12-31' } } }
+ * { foo: { $not: [ '2021-09-30', { $gte: '2021-10-07' } ] } }
+ * { foo: { $not: [ 'Leah', 'Nephalem' ] } }
+ * { $or: { title: 'Leah', content: 'Diablo' } }
+ * { $or: [ { title: 'Leah', content: 'Diablo' }, { title: 'Stranger' } ] }
+ * @param {Object} conditions
+ */
+function parseObject(conditions) {
+  if (!Spell) Spell = require('./spell');
+  const result = [];
+
+  for (const name of Object.keys(conditions)) {
+    const value = conditions[name];
+
+    if (value instanceof Spell) {
+      // { tagId: Tag.where({ deletedAt: null }).select('id') }
+      result.push({
+        type: 'op',
+        name: 'in',
+        args: [ parseExpr(name), { type: 'subquery', value } ]
+      });
+    } else if (isLogicalOperator(name)) {
+      // { $and: [ { title: 'Leah' }, { content: { $ne: 'Diablo' } } ] }
+      // { $or: { title: 'Leah', content: { $like: '%Leah%' } } }
+      result.push(parseLogicalOperator(name, value));
+    } else if (isOperatorCondition(value)) {
+      // { title: [ 'Nephalem', 'Stranger' ] }
+      // { title: { $ne: 'Leah', $like: 'L%h' } }
+      result.push(parseOperator(name, value));
+    } else if (isLogicalCondition(value)) {
+      // { title: { $or: [ 'Leah', { $ne: 'Diablo' } ] } }
+      result.push(parseNamedLogicalOperator(name, value));
+    } else {
+      // { title: 'Leah' }
+      result.push({
+        type: 'op',
+        name: '=',
+        args: [ parseExpr(name), parseValue(value) ],
+      });
+    }
+  }
+
+  return result;
+}
+
+module.exports = { parseObject };

--- a/src/query_object.js
+++ b/src/query_object.js
@@ -134,17 +134,18 @@ function parseLogicalOperator($op, value) {
     throw new Error(`unexpected logical operator value ${value}`);
   }
 
+  // { title: { $not: [ { $like: '%foo%' }, { $like: '%bar%' } ] } }
+  if (operator === 'not') {
+    const args = merge(value.map(entry => merge(parseObject(entry))));
+    return { type: 'op', name: operator, args: [ args ] };
+  }
+
   const result = merge(value.map(entry => merge(parseObject(entry))), operator);
   const { args } = result;
 
   // { title: { $or: [ 'Leah' ] } }
   // { title: { $and: { $ne: 'Leah' } } }
-  if (args.length === 1 && operator !== 'not') return args[0];
-
-  // { title: { $not: [ { $like: '%foo%' }, { $like: '%bar%' } ] } }
-  if (args.length > 1 && operator === 'not') {
-    return { type: 'op', name: operator, args: [ merge(args) ] };
-  }
+  if (args.length === 1) return args[0];
 
   return result;
 }

--- a/test/unit/query_object.test.js
+++ b/test/unit/query_object.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const assert = require('assert').strict;
+const SqlString = require('sqlstring');
+
+const { parseObject } = require('../../src/query_object');
+const { formatConditions, collectLiteral } = require('../../src/expr_formatter');
+const { Bone, connect } = require('../..');
+
+describe('=> parseObject', function() {
+  class Post extends Bone {
+    static table = 'articles'
+  }
+
+  let spell;
+
+  before(async function() {
+    Bone.driver = null;
+    await connect({
+      models: [ Post ],
+      database: 'leoric',
+      user: 'root',
+      port: process.env.MYSQL_PORT,
+    });
+
+    // create a stub spell to format conditions with Post model
+    spell = Post.all;
+  });
+
+  function query(object) {
+    const values = [];
+    const conditions = parseObject(object);
+    for (const condition of conditions) collectLiteral(values, condition);
+    return SqlString.format(formatConditions(spell, conditions), values);
+  }
+
+  it('{ field: Literal }', function() {
+    assert.equal(query({ title: null }), '`title` IS NULL');
+    assert.equal(query({ title: 'Leah' }), "`title` = 'Leah'");
+    assert.equal(query({ id: 42 }), '`id` = 42');
+    assert.equal(query({ id: [ 2, 3, 5, 7 ] }), '`id` IN (2, 3, 5, 7)');
+
+    assert.equal(
+      query({ title: [ 'Stranger', 'Tyrael' ] }),
+      "`title` IN ('Stranger', 'Tyrael')"
+    );
+  });
+
+  it('{ field: { $op: Literal } }', function() {
+    assert.equal(
+      query({ createdAt: { $gt: new Date(2012, 4, 15) } }),
+      "`gmt_create` > '2012-05-15 00:00:00.000'"
+    );
+  });
+
+  it('{ field: { $op: [ Literal, Literal, ... ] } }', function() {
+    assert.equal(
+      query({ wordCount: { $between: [800, 1000] } }),
+      '`word_count` BETWEEN 800 AND 1000'
+    );
+
+    assert.equal(
+      query({ wordCount: { $notBetween: [800, 1000] } }),
+      '`word_count` NOT BETWEEN 800 AND 1000'
+    );
+
+    assert.equal(
+      query({ title: { $not: [ 'Leah', 'Nephalem' ] } }),
+      "`title` NOT IN ('Leah', 'Nephalem')"
+    );
+
+    assert.equal(
+      query({ title: { $notIn: [ 'Leah', 'Nephalem' ] } }),
+      "`title` NOT IN ('Leah', 'Nephalem')"
+    );
+  });
+
+  it('{ field: { $logical: [ Literal, { $op: Literal }, ... ] } }', function() {
+    assert.equal(
+      query({ title: { $or: [ 'Leah', { $like: '%Leah%' } ] } }),
+      "`title` = 'Leah' OR `title` LIKE '%Leah%'"
+    );
+    assert.equal(
+      query({ createdAt: { $not: [ '2021-09-30', { $gte: '2021-10-07' } ] } }),
+      "NOT (`gmt_create` = '2021-09-30' AND `gmt_create` >= '2021-10-07')"
+    );
+    assert.equal(
+      query({ createdAt: { $not: { $gt: '2021-01-01', $lte: '2021-12-31' } } }),
+      "NOT (`gmt_create` > '2021-01-01' AND `gmt_create` <= '2021-12-31')"
+    );
+  });
+
+
+  it('{ $logical: { field: Literal, field2: Literal } }', function() {
+    assert.equal(
+      query({ $or: { title: 'Leah', content: 'Diablo' } }),
+      "`title` = 'Leah' OR `content` = 'Diablo'"
+    );
+  });
+
+  it('{ $logical: [ { field: Literal }, ... ] }', function() {
+    assert.equal(
+      query({ $or: [ { title: 'Leah', content: 'Diablo' }, { title: 'Stranger' } ] }),
+      "`title` = 'Leah' AND `content` = 'Diablo' OR `title` = 'Stranger'"
+    );
+  });
+});

--- a/test/unit/query_object.test.js
+++ b/test/unit/query_object.test.js
@@ -90,7 +90,6 @@ describe('=> parseObject', function() {
     );
   });
 
-
   it('{ $logical: { field: Literal, field2: Literal } }', function() {
     assert.equal(
       query({ $or: { title: 'Leah', content: 'Diablo' } }),
@@ -102,6 +101,17 @@ describe('=> parseObject', function() {
     assert.equal(
       query({ $or: [ { title: 'Leah', content: 'Diablo' }, { title: 'Stranger' } ] }),
       "`title` = 'Leah' AND `content` = 'Diablo' OR `title` = 'Stranger'"
+    );
+  });
+
+  it('{ $logical: { $logical: [ { field: Literal }, ... ] } }', function() {
+    assert.equal(
+      query({ $not: { $not: { $not: { title: 'Leah', content: 'Diablo' } } } }),
+      "NOT NOT NOT (`title` = 'Leah' AND `content` = 'Diablo')"
+    );
+    assert.equal(
+      query({ $not: { $or: [ { title: 'Leah', content: 'Diablo' }, { title: 'Stranger' } ] } }),
+      "NOT (`title` = 'Leah' AND `content` = 'Diablo' OR `title` = 'Stranger')"
     );
   });
 });

--- a/test/unit/spell.test.js
+++ b/test/unit/spell.test.js
@@ -119,7 +119,7 @@ describe('=> Spell', function() {
       Post.where({
         $or: {},
       }).toString();
-    }, /insufficient logical operator value/);
+    }, /unexpected logical operator value/);
   });
 
   it('where object condition with multiple operator', async () => {
@@ -496,13 +496,6 @@ describe('=> Spell', function() {
     assert.equal(
       Post.count().group('authorId').having(raw('count > 10')).orHaving('count = 5').toString(),
       'SELECT COUNT(*) AS `count`, `author_id` FROM `articles` WHERE `gmt_deleted` IS NULL GROUP BY `author_id` HAVING count > 10 OR `count` = 5'
-    );
-  });
-
-  it('orHaving with array attr', function() {
-    assert.equal(
-      Post.count().group('authorId').having([ 'count > ?', 10 ]).orHaving('count = 5').toString(),
-      'SELECT COUNT(*) AS `count`, `author_id` FROM `articles` WHERE `gmt_deleted` IS NULL GROUP BY `author_id` HAVING `count` > 10 OR `count` = 5'
     );
   });
 


### PR DESCRIPTION
- object condition parsing => src/query_object.js
- expression formatting => src/expr_formatter.js

currently the `spell` object is still passed along the `formatXxx()` functions in expr_formatter.js. There might be two ways to refactor this:

- Turn `formatXxx()` into `ExprFormatter()` instances with `this.spell`;
- Turn expr objects into `Expr`, `OpExpr`, etc. with `this.spell`;

both requires lots of work but without little perf improvements, hence postponded further.