### PR TITLE
fix: accept timestamps in snake case

### DIFF
--- a/src/bone.js
+++ b/src/bone.js
@@ -1518,7 +1518,9 @@ class Bone {
       const names = [ 'createdAt', 'updatedAt' ];
       if (paranoid) names.push('deletedAt');
       for (const name of names) {
-        if (!attributes.hasOwnProperty(name)) attributes[name] = DataTypes.DATE;
+        if (!attributes[name] && !attributes[snakeCase(name)]) {
+          attributes[name] = DataTypes.DATE;
+        }
       }
     }
 

--- a/test/unit/bone.test.js
+++ b/test/unit/bone.test.js
@@ -61,6 +61,16 @@ describe('=> Bone', function() {
       assert.equal(User.attributes.updatedAt, undefined);
       assert.equal(User.attributes.deletedAt, undefined);
     });
+
+    it('should not append timestamps if underscored', async function() {
+      class User extends Bone {}
+      User.init({ name: STRING, created_at: DATE, updated_at: DATE });
+      assert.equal(User.attributes.createdAt, undefined);
+      assert.equal(User.attributes.updatedAt, undefined);
+      assert.equal(User.attributes.deletedAt, undefined);
+      assert.ok(User.attributes.created_at);
+      assert.ok(User.attributes.updated_at);
+    });
   });
 
   describe('=> Bone.load()', function() {


### PR DESCRIPTION
do not add default timestamps if timestamps in snake case exists already