### PR TITLE
fix: logger.logQuery should be guarded in case of error

### DIFF
--- a/src/drivers/abstract/logger.js
+++ b/src/drivers/abstract/logger.js
@@ -12,7 +12,7 @@ class Logger {
   format(query, values, opts = {}) {
     const { command, sets } = opts;
 
-    if (['insert', 'upsert', 'update'].includes(command) && sets) {
+    if ([ 'insert', 'upsert', 'update' ].includes(command) && sets) {
       const { hideKeys } = this;
       const keys = Object.keys(sets);
       values = values.map((entry, i) => {

--- a/src/drivers/abstract/logger.js
+++ b/src/drivers/abstract/logger.js
@@ -13,7 +13,7 @@ class Logger {
   format(query, values, opts = {}) {
     const { command, sets } = opts;
 
-    if ([ 'insert', 'upsert', 'update' ].includes(command) && sets) {
+    if (['insert', 'upsert', 'update'].includes(command) && sets) {
       const { hideKeys } = this;
       const keys = Object.keys(sets);
       values = values.map((entry, i) => {
@@ -38,11 +38,17 @@ class Logger {
   }
 
   logQueryError(sql, err, duration, opts) {
+    if (this._opts.logQueryError) {
+      return this._opts.logQueryError(sql, err, duration, opts);
+    }
     // err is thrown by default hence not logged here
     console.error('[query] [%s] %s', duration, sql);
   }
 
   logMigration(name) {
+    if (this._opts.logMigration) {
+      return this._opts.logMigration(name);
+    }
     debug('[migration] %s', name);
   }
 }

--- a/src/drivers/abstract/logger.js
+++ b/src/drivers/abstract/logger.js
@@ -4,10 +4,9 @@ const debug = require('debug')('leoric');
 const SqlString = require('sqlstring');
 
 class Logger {
-  constructor(opts = {}) {
+  constructor(opts) {
     if (typeof opts === 'function') opts = { logQuery: opts };
-    this._opts = opts;
-    this.hideKeys = opts.hideKeys || [];
+    Object.assign(this, { hideKeys: [] }, opts);
   }
 
   format(query, values, opts = {}) {
@@ -25,30 +24,24 @@ class Logger {
     return SqlString.format(query.sql || query, values);
   }
 
-  logQuery(sql, duration, opts) {
-    if (this._opts.logQuery) {
-      try {
-        this._opts.logQuery(sql, duration, opts);
-      } catch (error) {
-        console.error(error);
-      }
-    } else {
-      debug('[query] [%s] %s', duration, sql);
+  tryLogQuery() {
+    try {
+      this.logQuery(...arguments);
+    } catch (error) {
+      console.error(error);
     }
   }
 
+  logQuery(sql, duration, opts) {
+    debug('[query] [%s] %s', duration, sql);
+  }
+
   logQueryError(sql, err, duration, opts) {
-    if (this._opts.logQueryError) {
-      return this._opts.logQueryError(sql, err, duration, opts);
-    }
     // err is thrown by default hence not logged here
     console.error('[query] [%s] %s', duration, sql);
   }
 
   logMigration(name) {
-    if (this._opts.logMigration) {
-      return this._opts.logMigration(name);
-    }
     debug('[migration] %s', name);
   }
 }

--- a/src/drivers/abstract/logger.js
+++ b/src/drivers/abstract/logger.js
@@ -4,9 +4,10 @@ const debug = require('debug')('leoric');
 const SqlString = require('sqlstring');
 
 class Logger {
-  constructor(opts) {
+  constructor(opts = {}) {
     if (typeof opts === 'function') opts = { logQuery: opts };
-    Object.assign(this, { hideKeys: [] }, opts);
+    this._opts = opts;
+    this.hideKeys = opts.hideKeys || [];
   }
 
   format(query, values, opts = {}) {
@@ -25,7 +26,15 @@ class Logger {
   }
 
   logQuery(sql, duration, opts) {
-    debug('[query] [%s] %s', duration, sql);
+    if (this._opts.logQuery) {
+      try {
+        this._opts.logQuery(sql, duration, opts);
+      } catch (error) {
+        console.error(error);
+      }
+    } else {
+      debug('[query] [%s] %s', duration, sql);
+    }
   }
 
   logQueryError(sql, err, duration, opts) {

--- a/src/drivers/mysql/index.js
+++ b/src/drivers/mysql/index.js
@@ -96,7 +96,7 @@ class MysqlDriver extends AbstractDriver {
       if (!opts.connection) connection.release();
     }
 
-    logger.logQuery(sql, Date.now() - start, opts);
+    logger.tryLogQuery(sql, Date.now() - start, opts);
     const [ results, fields ] = result;
     if (fields) return { rows: results, fields };
     return results;

--- a/src/drivers/postgres/index.js
+++ b/src/drivers/postgres/index.js
@@ -141,7 +141,7 @@ class PostgresDriver extends AbstractDriver {
         if (!spell.connection) connection.release();
       }
 
-      logger.logQuery(formatted, Date.now() - start, spell);
+      logger.tryLogQuery(formatted, Date.now() - start, spell);
       return result;
     }
 

--- a/src/drivers/sqlite/index.js
+++ b/src/drivers/sqlite/index.js
@@ -52,7 +52,7 @@ class SqliteDriver extends AbstractDriver {
       if (!opts.connection) connection.release();
     }
 
-    logger.logQuery(sql, Date.now() - start, opts);
+    logger.tryLogQuery(sql, Date.now() - start, opts);
     return result;
   }
 

--- a/test/unit/drivers/abstract/index.test.js
+++ b/test/unit/drivers/abstract/index.test.js
@@ -4,14 +4,14 @@ const assert = require('assert').strict;
 const { Logger } = require('../../../..');
 const AbstractDriver = require('../../../../src/drivers/abstract');
 
-describe('=> AbstractDriver#logger', function (){
-  it('should create logger by default', async function (){
+describe('=> AbstractDriver#logger', function() {
+  it('should create logger by default', async function() {
     const driver = new AbstractDriver();
     assert.ok(driver.logger);
     assert.ok(driver.logger instanceof Logger);
   });
 
-  it('should accept custom logger', async function (){
+  it('should accept custom logger', async function() {
     class CustomLogger extends Logger {};
     const driver = new AbstractDriver({ logger: new CustomLogger });
     assert.ok(driver.logger);

--- a/test/unit/drivers/abstract/index.test.js
+++ b/test/unit/drivers/abstract/index.test.js
@@ -4,17 +4,31 @@ const assert = require('assert').strict;
 const { Logger } = require('../../../..');
 const AbstractDriver = require('../../../../src/drivers/abstract');
 
-describe('=> AbstractDriver#logger', function() {
-  it('should create logger by default', async function() {
+describe('=> AbstractDriver#logger', function () {
+  it('should create logger by default', async function () {
     const driver = new AbstractDriver();
     assert.ok(driver.logger);
     assert.ok(driver.logger instanceof Logger);
   });
 
-  it('should accept custom logger', async function() {
-    class CustomLogger extends Logger {};
+  it('should accept custom logger', async function () {
+    class CustomLogger extends Logger { };
     const driver = new AbstractDriver({ logger: new CustomLogger });
     assert.ok(driver.logger);
     assert.ok(driver.logger instanceof CustomLogger);
+  });
+
+  it('should not throw error use tryLogQuery', async () => {
+    const driver = new AbstractDriver({
+      logger(sql, duration) {
+        throw new Error('logQuery error');
+      },
+    });
+    assert.ok(driver.logger);
+    assert.ok(driver.logger instanceof Logger);
+    assert.throws(() => {
+      driver.logger.logQuery('xx')
+    }, /logQuery error/i);
+    assert.doesNotThrow(() => driver.logger.tryLogQuery('xx'));
   });
 });

--- a/test/unit/drivers/abstract/index.test.js
+++ b/test/unit/drivers/abstract/index.test.js
@@ -27,7 +27,7 @@ describe('=> AbstractDriver#logger', function () {
     assert.ok(driver.logger);
     assert.ok(driver.logger instanceof Logger);
     assert.throws(() => {
-      driver.logger.logQuery('xx')
+      driver.logger.logQuery('xx');
     }, /logQuery error/i);
     assert.doesNotThrow(() => driver.logger.tryLogQuery('xx'));
   });

--- a/test/unit/drivers/abstract/index.test.js
+++ b/test/unit/drivers/abstract/index.test.js
@@ -4,15 +4,15 @@ const assert = require('assert').strict;
 const { Logger } = require('../../../..');
 const AbstractDriver = require('../../../../src/drivers/abstract');
 
-describe('=> AbstractDriver#logger', function () {
-  it('should create logger by default', async function () {
+describe('=> AbstractDriver#logger', function (){
+  it('should create logger by default', async function (){
     const driver = new AbstractDriver();
     assert.ok(driver.logger);
     assert.ok(driver.logger instanceof Logger);
   });
 
-  it('should accept custom logger', async function () {
-    class CustomLogger extends Logger { };
+  it('should accept custom logger', async function (){
+    class CustomLogger extends Logger {};
     const driver = new AbstractDriver({ logger: new CustomLogger });
     assert.ok(driver.logger);
     assert.ok(driver.logger instanceof CustomLogger);

--- a/test/unit/realm.test.js
+++ b/test/unit/realm.test.js
@@ -106,22 +106,6 @@ describe('=> Realm', () => {
       assert.equal(queries[0], 'SELECT 1');
     });
 
-    it('should be able to customize logger , even though logQuery will throw error', async () => {
-      const realm = new Realm({
-        port: process.env.MYSQL_PORT,
-        user: 'root',
-        database: 'leoric',
-        logger: {
-          logQuery(sql) {
-            throw new Error('asdf');
-          }
-        }
-      });
-      await realm.connect();
-      const res = await realm.driver.query('SELECT 1');
-      assert(res.rows);
-    });
-
 
     it('should reject if models option is not valid', async function() {
       await assert.rejects(async function() {

--- a/test/unit/realm.test.js
+++ b/test/unit/realm.test.js
@@ -106,6 +106,23 @@ describe('=> Realm', () => {
       assert.equal(queries[0], 'SELECT 1');
     });
 
+    it('should be able to customize logger , even though logQuery will throw error', async () => {
+      const realm = new Realm({
+        port: process.env.MYSQL_PORT,
+        user: 'root',
+        database: 'leoric',
+        logger: {
+          logQuery(sql) {
+            throw new Error('asdf');
+          }
+        }
+      });
+      await realm.connect();
+      const res = await realm.driver.query('SELECT 1');
+      assert(res.rows);
+    });
+
+
     it('should reject if models option is not valid', async function() {
       await assert.rejects(async function() {
         const realm = new Realm({

--- a/test/unit/realm.test.js
+++ b/test/unit/realm.test.js
@@ -106,7 +106,6 @@ describe('=> Realm', () => {
       assert.equal(queries[0], 'SELECT 1');
     });
 
-
     it('should reject if models option is not valid', async function() {
       await assert.rejects(async function() {
         const realm = new Realm({


### PR DESCRIPTION
#39 logger.logQuery should be guarded in case of error