### PR TITLE
breaking: logQueryError(err, sql, duration, options)

### DIFF
--- a/src/drivers/mysql/index.js
+++ b/src/drivers/mysql/index.js
@@ -93,7 +93,7 @@ class MysqlDriver extends AbstractDriver {
     try {
       result = await promise;
     } catch (err) {
-      logger.logQueryError(sql, err, calculateDuration(start), opts);
+      logger.logQueryError(err, sql, calculateDuration(start), opts);
       throw err;
     } finally {
       if (!opts.connection) connection.release();

--- a/src/drivers/postgres/index.js
+++ b/src/drivers/postgres/index.js
@@ -137,7 +137,7 @@ class PostgresDriver extends AbstractDriver {
       try {
         result = await connection.query(...args);
       } catch (err) {
-        logger.logQueryError(formatted, err, calculateDuration(start), spell);
+        logger.logQueryError(err, formatted, calculateDuration(start), spell);
         throw err;
       } finally {
         if (!spell.connection) connection.release();

--- a/src/drivers/sqlite/index.js
+++ b/src/drivers/sqlite/index.js
@@ -48,7 +48,7 @@ class SqliteDriver extends AbstractDriver {
     try {
       result = await connection.query(query, values, opts);
     } catch (err) {
-      logger.logQueryError(sql, err, calculateDuration(start), opts);
+      logger.logQueryError(err, sql, calculateDuration(start), opts);
       throw err;
     } finally {
       if (!opts.connection) connection.release();

--- a/test/unit/drivers/mysql/index.test.js
+++ b/test/unit/drivers/mysql/index.test.js
@@ -38,7 +38,7 @@ describe('=> MySQL driver', () => {
       },
     });
     await assert.rejects(async () => await driver2.query('SELECT x'));
-    const [ sql, err ] = result[0];
+    const [ err, sql ] = result[0];
     assert.equal(sql, 'SELECT x');
     assert.ok(err);
     assert.ok(/ER_BAD_FIELD_ERROR/.test(err.message));

--- a/test/unit/drivers/postgres/index.test.js
+++ b/test/unit/drivers/postgres/index.test.js
@@ -38,7 +38,7 @@ describe('=> PostgreSQL driver', () => {
       },
     });
     await assert.rejects(async () => await driver2.query('SELECT x'));
-    const [ sql, err ] = result[0];
+    const [ err, sql ] = result[0];
     assert.equal(sql, 'SELECT x');
     assert.ok(err);
     assert.ok(/column "x" does not exist/.test(err.message));

--- a/test/unit/drivers/sqlite/index.test.js
+++ b/test/unit/drivers/sqlite/index.test.js
@@ -40,7 +40,7 @@ describe('=> SQLite driver', () => {
       },
     });
     await assert.rejects(async () => await driver2.query('SELECT x'));
-    const [ sql, err ] = result[0];
+    const [ err, sql ] = result[0];
     assert.equal(sql, 'SELECT x');
     assert.ok(err);
     assert.ok(/no such column/.test(err.message));


### PR DESCRIPTION
to correct a bad design in v1.x, change from `logQueryError(sql, err, ...)` to `logQueryError(err, sql, ...)`