### PR TITLE
fix: should not hoist subquery if query is ordered by external columns

### DIFF
--- a/src/drivers/abstract/spellbook.js
+++ b/src/drivers/abstract/spellbook.js
@@ -220,13 +220,13 @@ function formatSelectWithJoin(spell) {
 
   let hoistable = skip > 0 || rowCount > 0;
   if (hoistable) {
-    for (const condition of whereConditions) {
-      walkExpr(condition, ({ type, qualifiers }) => {
-        if (type === 'id' && qualifiers.length> 0 && !qualifiers.includes(baseName)) {
-          hoistable = false;
-        }
-      });
+    function checkQualifier({ type, qualifiers }) {
+      if (type === 'id' && qualifiers.length> 0 && !qualifiers.includes(baseName)) {
+        hoistable = false;
+      }
     }
+    for (const condition of whereConditions) walkExpr(condition, checkQualifier);
+    for (const orderExpr of orders) walkExpr(orderExpr[0], checkQualifier);
   }
 
   if (hoistable) {

--- a/test/integration/suite/associations.test.js
+++ b/test/integration/suite/associations.test.js
@@ -143,7 +143,7 @@ describe('=> Associations', function() {
   });
 
   it('.with(...names).order()', async function() {
-    const post = await Post.include('comments').order('comments.content asc').first;
+    const [ post ] = await Post.include('comments').order('posts.id asc').order('comments.content asc');
     expect(post.comments.map(comment => comment.content)).to.eql(comments.sort());
 
     const posts = await Post.include('comments').order({ 'posts.title': 'desc', 'comments.content': 'desc' });
@@ -153,7 +153,7 @@ describe('=> Associations', function() {
   });
 });
 
-describe('=> Associations offset / limit', function() {
+describe('=> Associations order / offset / limit', function() {
   before(async function() {
     const post1 = await Post.create({ title: 'New Post' });
     await Comment.create({ content: 'Abandon your foolish request!', articleId: post1.id });
@@ -181,6 +181,12 @@ describe('=> Associations offset / limit', function() {
     const posts = await Post.include('comments').where({
       'comments.content': { $like: '%child%' },
     }).limit(1);
+    assert.equal(posts.length, 1);
+    assert.equal(posts[0].title, 'New Post 2');
+  });
+
+  it('should not limit subquery if ordered by joined columns', async function() {
+    const posts = await Post.include('comments').order('comments.content', 'desc').limit(1);
     assert.equal(posts.length, 1);
     assert.equal(posts[0].title, 'New Post 2');
   });


### PR DESCRIPTION
```js
const result = await Post.include('comments').order('comments.id', 'desc').order('posts.id', 'desc').limit(1);
```

This query might retrives wrong result because the post with latest comments isn't necessarily the latest one, such as:

| post_id | comment_id |
|---------|------------|
| 1       | 3          |
| 2       | 2          |
| 3       | 1          |

Previous implementation will yield SQL like:

```sql
SELECT posts.*, comments.*
  FROM (SELECT * FROM posts ORDER BY id DESC)
    AS posts
  LEFT JOIN comments ON posts.id = comments.post_id
 ORDER BY comments.id desc
```

which retrives `Post<#id 3>`, but `Post<#id 1>` is the one with the latest comment.