### PR TITLE
fix: order by alias should not throw

### DIFF
--- a/src/drivers/abstract/spellbook.js
+++ b/src/drivers/abstract/spellbook.js
@@ -129,7 +129,7 @@ function createSubspell(spell) {
   subspell.orders = [];
   for (const order of orders) {
     const [token, direction] = order;
-    const { type, qualifiers, value } = token;
+    const { type, qualifiers = [], value } = token;
     if (type == 'id' && qualifiers[0] == baseName) {
       subspell.orders.push([{ type, value }, direction]);
     }
@@ -220,7 +220,7 @@ function formatSelectWithJoin(spell) {
 
   let hoistable = skip > 0 || rowCount > 0;
   if (hoistable) {
-    function checkQualifier({ type, qualifiers }) {
+    function checkQualifier({ type, qualifiers = [] }) {
       if (type === 'id' && qualifiers.length> 0 && !qualifiers.includes(baseName)) {
         hoistable = false;
       }

--- a/test/integration/suite/associations.test.js
+++ b/test/integration/suite/associations.test.js
@@ -198,4 +198,9 @@ describe('=> Associations order / offset / limit', function() {
     // both posts have comments with content containing `oo` but only one should return
     assert.equal(posts.length, 1);
   });
+
+  it('should not throw if select and order by alias', async function() {
+    const result = await Post.include('comments').select('content as cnt').order('cnt', 'desc').limit(1);
+    assert.equal(result.length, 1);
+  });
 });


### PR DESCRIPTION
```js
     TypeError: Cannot read property 'length' of undefined
      at checkQualifier (src/drivers/abstract/spellbook.js:224:39)
      at walkExpr (src/expr.js:415:3)
      at Object.formatSelectWithJoin (src/drivers/abstract/spellbook.js:229:37)
      at Object.formatSelect (src/drivers/abstract/spellbook.js:292:12)
      at Object.format (src/drivers/abstract/spellbook.js:572:21)
      at MysqlDriver.format (src/drivers/mysql/index.js:109:22)
      at Spell.ignite (src/spell.js:428:42)
      at Spell.then (src/spell.js:447:17)
```