### PR TITLE
fix: type checking adaption

### DIFF
--- a/src/data_types.js
+++ b/src/data_types.js
@@ -187,15 +187,18 @@ class INTEGER extends DataType {
   }
 
   cast(value) {
-    if (value == null) return value;
+    if (value == null || isNaN(value)) return value;
     return Number(value);
   }
 
-  uncast(value) {
+  uncast(value, strict = true) {
     const originValue = value;
     if (value == null || value instanceof Raw) return value;
     if (typeof value === 'string') value = parseInt(value, 10);
-    if (isNaN(value)) throw new Error(util.format('invalid integer: %s', originValue));
+    if (isNaN(value)) {
+      if (strict) throw new Error(util.format('invalid integer: %s', originValue));
+      return originValue;
+    }
     return value;
   }
 }
@@ -244,8 +247,10 @@ class DATE extends DataType {
   }
 
   cast(value) {
+    const original = value;
     if (value == null) return value;
     if (!(value instanceof Date)) value = new Date(value);
+    if (isNaN(value.getTime())) return original;
     return this._round(value);
   }
 
@@ -290,8 +295,10 @@ class DATEONLY extends DataType {
   }
 
   cast(value) {
+    const original = value;
     if (value == null) return value;
     if (!(value instanceof Date)) value = new Date(value);
+    if (isNaN(value.getTime())) return original;
     return this._round(value);
   }
 
@@ -310,7 +317,7 @@ class DATEONLY extends DataType {
     }
 
     if (!(value instanceof Date)) value = new Date(value);
-    if (isNaN(value)) throw new Error(util.format('invalid date: %s', originValue));;
+    if (isNaN(value)) throw new Error(util.format('invalid date: %s', originValue));
 
     return this._round(value);
   }

--- a/src/drivers/abstract/attribute.js
+++ b/src/drivers/abstract/attribute.js
@@ -126,11 +126,11 @@ class Attribute {
     return this.type.cast(value);
   }
 
-  uncast(value) {
+  uncast(value, strict = true) {
     if (Array.isArray(value) && this.jsType !== JSON) {
-      return value.map(entry => this.type.uncast(entry));
+      return value.map(entry => this.type.uncast(entry, strict));
     }
-    return this.type.uncast(value);
+    return this.type.uncast(value, strict);
   }
 }
 

--- a/src/drivers/postgres/data_types.js
+++ b/src/drivers/postgres/data_types.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const DataTypes = require('../../data_types');
+const util = require('util');
+const Raw = require('../../raw');
+
 
 class Postgres_DATE extends DataTypes.DATE {
   constructor(precision, timezone = true) {
@@ -37,12 +40,35 @@ class Postgres_BINARY extends DataTypes {
   }
 }
 
+class Postgres_INTEGER extends DataTypes.INTEGER {
+  constructor(length) {
+    super(length);
+  }
+
+  uncast(value) {
+    const originValue = value;
+    if (value == null || value instanceof Raw) return value;
+    if (typeof value === 'string') value = parseInt(value, 10);
+    if (isNaN(value)) throw new Error(util.format('invalid integer: %s', originValue));
+    return value;
+  }
+}
+
+class Postgres_BIGINT extends Postgres_INTEGER {
+  constructor() {
+    super();
+    this.dataType = 'bigint';
+  }
+}
+
 class Postgres_DataTypes extends DataTypes {
   static DATE = Postgres_DATE;
   static JSONB = Postgres_JSONB;
   static BINARY = Postgres_BINARY;
   static VARBINARY = Postgres_BINARY;
   static BLOB = Postgres_BINARY;
+  static INTEGER = Postgres_INTEGER;
+  static BIGINT =  Postgres_BIGINT;
 }
 
 module.exports = Postgres_DataTypes;

--- a/src/drivers/sqlite/data_types.js
+++ b/src/drivers/sqlite/data_types.js
@@ -7,8 +7,42 @@ class Sqlite_DATE extends DataTypes.DATE {
     super(precision, timezone);
     this.dataType = 'datetime';
   }
+
+  uncast(value) {
+    try {
+      return super.uncast(value);
+    } catch (error) {
+      console.error(new Error(`unable to cast ${value} to DATE`));
+      return value;
+    }
+  }
 }
 
+class Sqlite_DATEONLY extends DataTypes.DATEONLY {
+  constructor() {
+    super();
+  }
+
+  uncast(value) {
+    try {
+      return super.uncast(value);
+    } catch (error) {
+      console.error(new Error(`unable to cast ${value} to DATEONLY`));
+      return value;
+    }
+  }
+}
+
+class Sqlite_INTEGER extends DataTypes.INTEGER {
+  constructor(length) {
+    super(length);
+  }
+
+  uncast(value) {
+    return super.uncast(value, false);
+  }
+
+}
 class Sqlite_BIGINT extends DataTypes.BIGINT {
   constructor() {
     super();
@@ -57,6 +91,14 @@ class Sqlite_DataTypes extends DataTypes {
 
   static get VARBINARY() {
     return Sqlite_VARBINARY;
+  }
+
+  static get DATEONLY() {
+    return Sqlite_DATEONLY;
+  }
+
+  static get INTEGER() {
+    return Sqlite_INTEGER;
   }
 }
 

--- a/src/expr_formatter.js
+++ b/src/expr_formatter.js
@@ -208,7 +208,7 @@ function coerceLiteral(spell, ast) {
     if (arg.type === 'literal') {
       // { params: { $like: '%foo%' } }
       if (attribute.jsType === JSON && typeof arg.value === 'string') continue;
-      arg.value = attribute.uncast(arg.value);
+      arg.value = attribute.uncast(arg.value, false);
     }
   }
 }

--- a/test/unit/data_types.test.js
+++ b/test/unit/data_types.test.js
@@ -4,6 +4,9 @@ const assert = require('assert').strict;
 const dayjs = require('dayjs');
 const DataTypes = require('../../src/data_types');
 const Raw = require('../../src/raw');
+const Postgres_DataTypes = require('../../src/drivers/postgres/data_types');
+const SQLite_DataTypes = require('../../src/drivers/sqlite/data_types');
+
 
 
 describe('=> Data Types', () => {
@@ -83,7 +86,27 @@ describe('=> Data Types', () => {
 });
 
 describe('=> DataTypes type casting', function() {
-  const { STRING, BLOB, DATE, DATEONLY, JSON } = DataTypes;
+  const { STRING, BLOB, DATE, DATEONLY, JSON, INTEGER } = DataTypes;
+
+  it('INTEGER', async () => {
+    assert.equal(new INTEGER().uncast(null), null);
+    assert.equal(new INTEGER().uncast(undefined), undefined);
+    assert.equal(new INTEGER().uncast('1'), 1);
+    assert.equal(new INTEGER().uncast(1), 1);
+
+    await assert.rejects(async () => {
+      new Postgres_DataTypes.INTEGER().uncast('yes?');
+    }, /Error: invalid integer: yes?/);
+
+    assert.equal(new SQLite_DataTypes.INTEGER().uncast('yes?'), 'yes?');
+
+    await assert.rejects(async () => {
+      new INTEGER().uncast('yes?');
+    }, /Error: invalid integer: yes?/);
+  
+    assert.equal(new INTEGER().uncast('yes?', false), 'yes?');
+
+  });
 
   it('STRING', async function() {
     assert.equal(new STRING().uncast(null), null);
@@ -112,6 +135,13 @@ describe('=> DataTypes type casting', function() {
 
     // raw
     assert.deepEqual(new DATE().uncast(new Raw(`NOW()`)), new Raw(`NOW()`));
+
+    await assert.rejects(async () => {
+      new DATE().uncast('yes?');
+    }, /Error: invalid date: yes?/);
+
+    assert.deepEqual(new SQLite_DataTypes.DATE().uncast('yes?'), 'yes?');
+
   });
 
   it('DATE toDate()', async function() {
@@ -133,6 +163,12 @@ describe('=> DataTypes type casting', function() {
     today.setHours(0);
     assert.equal(result.getTime(), today.getTime());
     assert.deepEqual(new DATEONLY().uncast(new Raw(`NOW()`)), new Raw(`NOW()`));
+
+    await assert.rejects(async () => {
+      new DATEONLY().uncast('yes?');
+    }, /Error: invalid date: yes?/);
+
+    assert.deepEqual(new SQLite_DataTypes.DATEONLY().uncast('yes?'), 'yes?');
   });
 
   it('DATEONLY toDate()', async function() {


### PR DESCRIPTION
DB/DataType(validate or not in SQL operations) | INTEGER | DATE
-- | -- | --
MySQL | 🔲query ✅insert | ✅query ✅insert
SQLlite | 🔲query 🔲insert | 🔲query 🔲insert
PostgresSQL | ✅query ✅insert | ✅query ✅insert
