### PR TITLE
fix: attribute.defaultValue should be set when init attributes

### DIFF
--- a/src/bone.js
+++ b/src/bone.js
@@ -152,7 +152,6 @@ class Bone {
     }
   }
 
-
   /**
    * Get or set attribute value by name. This method is quite similiar to `jQuery.attr()`. If the attribute isn't selected when queried from database, an error will be thrown when accessing it.
    *

--- a/src/drivers/postgres/schema.js
+++ b/src/drivers/postgres/schema.js
@@ -57,13 +57,18 @@ module.exports = {
 
       if (dataType === 'character varying') dataType = 'varchar';
       if (dataType === 'timestamp without time zone') dataType = 'timestamp';
+
+      let columnDefault = row.column_default;
+      if (/^NULL::/i.test(columnDefault)) columnDefault = null;
+      if (dataType === 'boolean') columnDefault = columnDefault === 'true';
+
       const primaryKey = row.constraint_type === 'PRIMARY KEY';
       const precision = row.datetime_precision;
 
       columns.push({
         columnName: row.column_name,
         columnType: length > 0 ? `${dataType}(${length})` : dataType,
-        defaultValue: primaryKey ? null : row.column_default,
+        defaultValue: primaryKey ? null : columnDefault,
         dataType,
         allowNull: row.is_nullable !== 'NO',
         // https://www.postgresql.org/docs/9.5/infoschema-table-constraints.html

--- a/src/drivers/sqlite/schema.js
+++ b/src/drivers/sqlite/schema.js
@@ -75,8 +75,9 @@ async function alterTableWithChangeColumn(driver, table, changes) {
 }
 
 // eslint-disable-next-line no-unused-vars
-function parseDefaultValue(text) {
+function parseDefaultValue(text, type) {
   if (typeof text !== 'string') return text;
+  if (type === 'boolean') return text === 'true';
 
   try {
     const ast = parseExpr(text);
@@ -84,7 +85,7 @@ function parseDefaultValue(text) {
       return ast.value;
     }
   } catch (err) {
-    debug('[parseDefaultValue] [%s] %s', text, err.stack);
+    debug('[parseDefaultValue] [%s] %s', text, err);
   }
 
   return text;
@@ -111,10 +112,11 @@ module.exports = {
         const columnType = type.toLowerCase();
         const [, dataType, precision ] = columnType.match(rColumnType);
         const primaryKey = pk === 1;
+
         const result = {
           columnName: name,
           columnType,
-          defaultValue: parseDefaultValue(dflt_value),
+          defaultValue: parseDefaultValue(dflt_value, type),
           dataType: dataType,
           allowNull: primaryKey ? false : notnull == 0,
           primaryKey,

--- a/src/realm.js
+++ b/src/realm.js
@@ -49,9 +49,8 @@ function initAttributes(model, columns) {
   const attributes = {};
 
   for (const columnInfo of columns) {
-    const { columnName, columnType, defaultValue, ...restInfo } = columnInfo;
+    const { columnName, columnType, ...restInfo } = columnInfo;
     const name = columnName === '_id' ? columnName : camelCase(columnName);
-    // leave out defaultValue to let database take over the default
     attributes[name] = {
       ...restInfo,
       columnName,

--- a/test/dumpfile.sql
+++ b/test/dumpfile.sql
@@ -9,7 +9,7 @@ CREATE TABLE `articles` (
   `extra` text,
   `thumb` varchar(1000) DEFAULT NULL,
   `author_id` bigint(20) DEFAULT NULL,
-  `is_private` tinyint(1) DEFAULT 0,
+  `is_private` tinyint(1) DEFAULT 0 NOT NULL,
   `summary` text,
   `word_count` int DEFAULT 0,
   `settings` text

--- a/test/integration/postgres.test.js
+++ b/test/integration/postgres.test.js
@@ -55,14 +55,14 @@ describe('=> upsert', function () {
   it('upsert', function() {
     assert.equal(
       new Post({ id: 1, title: 'New Post', createdAt: raw('CURRENT_TIMESTAMP()'), updatedAt: raw('CURRENT_TIMESTAMP()') }).upsert().toString(),
-      'INSERT INTO "articles" ("id", "title", "gmt_create", "gmt_modified") VALUES (1, \'New Post\', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()) ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "gmt_modified"=EXCLUDED."gmt_modified" RETURNING "id"'
+      `INSERT INTO "articles" ("id", "title", "is_private", "word_count", "gmt_create", "gmt_modified") VALUES (1, 'New Post', false, 0, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()) ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "is_private"=EXCLUDED."is_private", "word_count"=EXCLUDED."word_count", "gmt_modified"=EXCLUDED."gmt_modified" RETURNING "id"`
     );
   });
 
   it('upsert returning multiple columns', function() {
     assert.equal(
       new Post({ id: 1, title: 'New Post', createdAt: raw('CURRENT_TIMESTAMP()'), updatedAt: raw('CURRENT_TIMESTAMP()') }).upsert({ returning: [ 'id', 'title' ] }).toString(),
-      'INSERT INTO "articles" ("id", "title", "gmt_create", "gmt_modified") VALUES (1, \'New Post\', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()) ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "gmt_modified"=EXCLUDED."gmt_modified" RETURNING "id", "title"'
+      `INSERT INTO "articles" ("id", "title", "is_private", "word_count", "gmt_create", "gmt_modified") VALUES (1, 'New Post', false, 0, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()) ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "is_private"=EXCLUDED."is_private", "word_count"=EXCLUDED."word_count", "gmt_modified"=EXCLUDED."gmt_modified" RETURNING "id", "title"`
     );
   });
 });

--- a/test/integration/sqlite.test.js
+++ b/test/integration/sqlite.test.js
@@ -61,7 +61,7 @@ describe('=> upsert (sqlite)', function () {
   it('upsert', function() {
     assert.equal(
       new Post({ id: 1, title: 'New Post', createdAt: raw('CURRENT_TIMESTAMP()'), updatedAt: raw('CURRENT_TIMESTAMP()') }).upsert().toString(),
-      'INSERT INTO "articles" ("id", "title", "gmt_create", "gmt_modified") VALUES (1, \'New Post\', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()) ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "gmt_modified"=EXCLUDED."gmt_modified"'
+      `INSERT INTO "articles" ("id", "title", "is_private", "word_count", "gmt_create", "gmt_modified") VALUES (1, 'New Post', false, 0, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()) ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "is_private"=EXCLUDED."is_private", "word_count"=EXCLUDED."word_count", "gmt_modified"=EXCLUDED."gmt_modified"`
     );
   });
 });

--- a/test/integration/suite/basics.test.js
+++ b/test/integration/suite/basics.test.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const assert = require('assert').strict;
@@ -39,7 +38,6 @@ describe('=> Basic', () => {
         extra: { versions: [2, 3] },
         thumb: 'https://a1.alicdn.com/image/2016/09/21/29f93b05-5d4a-4b57-99e8-71c52803b9a3.png'
       });
-
     });
 
     afterEach(async function () {
@@ -233,12 +231,18 @@ describe('=> Basic', () => {
 
     it('Bone.changes(): raw VS rawSaved', async function () {
       const post = new Post({ title: 'Untitled' });
-      assert.deepEqual(post.changes(), { title: [ null, 'Untitled' ] });
+      assert.deepEqual(post.changes(), {
+        isPrivate: [ null, Post.driver.type === 'mysql' ? 0 : false ],
+        title: [ null, 'Untitled' ],
+        wordCount: [ null, 0 ],
+      });
       post.title = 'MHW';
       post.content = 'Iceborne';
       assert.deepEqual(post.changes(), {
+        isPrivate: [ null, Post.driver.type === 'mysql' ? 0 : false ],
         title: [ null, 'MHW' ],
         content: [ null, 'Iceborne' ],
+        wordCount: [ null, 0 ],
       });
       await post.save();
       assert.deepEqual(post.changes(), {});

--- a/test/unit/adapters/sequelize.test.js
+++ b/test/unit/adapters/sequelize.test.js
@@ -1020,12 +1020,33 @@ describe('=> Sequelize adapter', () => {
   it('model.previous()', async () => {
     const post = await Post.create({ title: 'By three they come' });
     post.title = 'Hello there';
-    assert.deepEqual(post.previous(), { title: 'By three they come', id: post.id, updatedAt: post.updatedAt, createdAt: post.createdAt });
+    assert.deepEqual(post.previous(), {
+      title: 'By three they come',
+      id: post.id,
+      isPrivate: false,
+      updatedAt: post.updatedAt,
+      createdAt: post.createdAt,
+      wordCount: 0,
+    });
     post.content = 'a';
-    assert.deepEqual(post.previous(), { title: 'By three they come', id: post.id, updatedAt: post.updatedAt, createdAt: post.createdAt });
+    assert.deepEqual(post.previous(), {
+      title: 'By three they come',
+      id: post.id,
+      isPrivate: false,
+      updatedAt: post.updatedAt,
+      createdAt: post.createdAt,
+      wordCount: 0,
+    });
     const prevUpdatedAt = post.updatedAt;
     await post.update();
-    assert.deepEqual(post.previous(), { title: 'By three they come', id: post.id, updatedAt: prevUpdatedAt, createdAt: post.createdAt });
+    assert.deepEqual(post.previous(), {
+      title: 'By three they come',
+      id: post.id,
+      isPrivate: false,
+      updatedAt: prevUpdatedAt,
+      createdAt: post.createdAt,
+      wordCount: 0,
+    });
   });
 
   it('model.update(values, { paranoid })', async () => {
@@ -1902,7 +1923,7 @@ describe('Model.update with order, limit (mysql only)', () => {
     assert.equal(allPosts[2].title, 'Throne');
     assert.equal(allPosts[3].title, 'Throne');
 
-  
+
   });
 
 

--- a/test/unit/hint.test.js
+++ b/test/unit/hint.test.js
@@ -68,13 +68,13 @@ describe('MySQL', async () => {
         Post.create({ title: 'New Post', createdAt: date, updatedAt: date }, {
           hint: new Hint('SET_VAR(foreign_key_checks=OFF)')
         }).toString(),
-        "INSERT /*+ SET_VAR(foreign_key_checks=OFF) */ INTO `articles` (`title`, `gmt_create`, `gmt_modified`) VALUES ('New Post', '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
+        "INSERT /*+ SET_VAR(foreign_key_checks=OFF) */ INTO `articles` (`is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (0, 'New Post', 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
       );
       assert.equal(
         Post.create({ title: 'New Post', createdAt: date, updatedAt: date })
           .optimizerHints('SET_VAR(foreign_key_checks=OFF)')
           .toString(),
-        "INSERT /*+ SET_VAR(foreign_key_checks=OFF) */ INTO `articles` (`title`, `gmt_create`, `gmt_modified`) VALUES ('New Post', '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
+        "INSERT /*+ SET_VAR(foreign_key_checks=OFF) */ INTO `articles` (`is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (0, 'New Post', 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
       );
       // array
       assert.equal(
@@ -84,19 +84,19 @@ describe('MySQL', async () => {
             new Hint('SET_VAR(sort_buffer_size = 16M)'),
           ],
         }).toString(),
-        "INSERT /*+ SET_VAR(foreign_key_checks=OFF) SET_VAR(sort_buffer_size = 16M) */ INTO `articles` (`title`, `gmt_create`, `gmt_modified`) VALUES ('New Post', '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
+        "INSERT /*+ SET_VAR(foreign_key_checks=OFF) SET_VAR(sort_buffer_size = 16M) */ INTO `articles` (`is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (0, 'New Post', 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
       );
 
       assert.equal(
         Post.create({ title: 'New Post', createdAt: date, updatedAt: date })
           .optimizerHints('SET_VAR(foreign_key_checks=OFF)', 'SET_VAR(sort_buffer_size = 16M)')
           .toString(),
-        "INSERT /*+ SET_VAR(foreign_key_checks=OFF) SET_VAR(sort_buffer_size = 16M) */ INTO `articles` (`title`, `gmt_create`, `gmt_modified`) VALUES ('New Post', '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
+        "INSERT /*+ SET_VAR(foreign_key_checks=OFF) SET_VAR(sort_buffer_size = 16M) */ INTO `articles` (`is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (0, 'New Post', 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
       );
 
       assert.equal(
         Post.create({ title: 'New Post', createdAt: date, updatedAt: date }).optimizerHints('SET_VAR(foreign_key_checks=OFF)').optimizerHints('SET_VAR(sort_buffer_size = 16M)').toString(),
-        "INSERT /*+ SET_VAR(foreign_key_checks=OFF) SET_VAR(sort_buffer_size = 16M) */ INTO `articles` (`title`, `gmt_create`, `gmt_modified`) VALUES ('New Post', '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
+        "INSERT /*+ SET_VAR(foreign_key_checks=OFF) SET_VAR(sort_buffer_size = 16M) */ INTO `articles` (`is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (0, 'New Post', 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
       );
 
       assert.equal(
@@ -107,7 +107,7 @@ describe('MySQL', async () => {
             new Hint('BKA(users)'),
           ],
         }).toString(),
-        "INSERT /*+ SET_VAR(foreign_key_checks=OFF) SET_VAR(sort_buffer_size = 16M) BKA(users) */ INTO `articles` (`title`, `gmt_create`, `gmt_modified`) VALUES ('New Post', '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
+        "INSERT /*+ SET_VAR(foreign_key_checks=OFF) SET_VAR(sort_buffer_size = 16M) BKA(users) */ INTO `articles` (`is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (0, 'New Post', 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
       );
 
       assert.equal(
@@ -115,7 +115,7 @@ describe('MySQL', async () => {
           hint: new Hint('SET_VAR(optimizer_switch = \'mrr_cost_based=off\')'),
           hints: [ new Hint('SET_VAR(foreign_key_checks=OFF)'), new Hint('SET_VAR(sort_buffer_size = 16M)') ]
         }).toString(),
-        "INSERT /*+ SET_VAR(foreign_key_checks=OFF) SET_VAR(sort_buffer_size = 16M) SET_VAR(optimizer_switch = 'mrr_cost_based=off') */ INTO `articles` (`title`, `gmt_create`, `gmt_modified`) VALUES ('New Post', '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
+        "INSERT /*+ SET_VAR(foreign_key_checks=OFF) SET_VAR(sort_buffer_size = 16M) SET_VAR(optimizer_switch = 'mrr_cost_based=off') */ INTO `articles` (`is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (0, 'New Post', 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
       );
     });
 

--- a/test/unit/spell.test.js
+++ b/test/unit/spell.test.js
@@ -49,7 +49,7 @@ describe('=> Spell', function() {
     const date = new Date(2017, 11, 12);
     assert.equal(
       Post.create({ title: 'New Post', createdAt: date, updatedAt: date }).toString(),
-      "INSERT INTO `articles` (`title`, `gmt_create`, `gmt_modified`) VALUES ('New Post', '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
+      "INSERT INTO `articles` (`is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (0, 'New Post', 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000')"
     );
   });
 
@@ -57,7 +57,7 @@ describe('=> Spell', function() {
     const date = new Date(2017, 11, 12);
     assert.equal(
       new Post({ id: 1, title: 'New Post', createdAt: date, updatedAt: date }).upsert().toString(),
-      "INSERT INTO `articles` (`id`, `title`, `gmt_create`, `gmt_modified`) VALUES (1, 'New Post', '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON DUPLICATE KEY UPDATE `id` = LAST_INSERT_ID(`id`), `id`=VALUES(`id`), `title`=VALUES(`title`), `gmt_modified`=VALUES(`gmt_modified`)"
+      "INSERT INTO `articles` (`id`, `is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (1, 0, 'New Post', 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON DUPLICATE KEY UPDATE `id` = LAST_INSERT_ID(`id`), `id`=VALUES(`id`), `is_private`=VALUES(`is_private`), `title`=VALUES(`title`), `word_count`=VALUES(`word_count`), `gmt_modified`=VALUES(`gmt_modified`)"
     );
   });
 
@@ -677,7 +677,7 @@ describe('=> Spell', function() {
   it('create with raw sql', function() {
     assert.equal(
       Post.create({ title: 'New Post', createdAt: raw('CURRENT_TIMESTAMP()'), updatedAt: raw('CURRENT_TIMESTAMP()') }).toString(),
-      "INSERT INTO `articles` (`title`, `gmt_create`, `gmt_modified`) VALUES ('New Post', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP())"
+      "INSERT INTO `articles` (`is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (0, 'New Post', 0, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP())"
     );
   });
 
@@ -729,7 +729,7 @@ describe('=> Spell', function() {
   it('upsert with raw sql', function () {
     assert.equal(
       new Post({ id: 1, title: 'New Post', createdAt: raw('CURRENT_TIMESTAMP()'), updatedAt: raw('CURRENT_TIMESTAMP()') }).upsert().toString(),
-      "INSERT INTO `articles` (`id`, `title`, `gmt_create`, `gmt_modified`) VALUES (1, 'New Post', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()) ON DUPLICATE KEY UPDATE `id` = LAST_INSERT_ID(`id`), `id`=VALUES(`id`), `title`=VALUES(`title`), `gmt_modified`=VALUES(`gmt_modified`)"
+      "INSERT INTO `articles` (`id`, `is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (1, 0, 'New Post', 0, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()) ON DUPLICATE KEY UPDATE `id` = LAST_INSERT_ID(`id`), `id`=VALUES(`id`), `is_private`=VALUES(`is_private`), `title`=VALUES(`title`), `word_count`=VALUES(`word_count`), `gmt_modified`=VALUES(`gmt_modified`)"
     );
   });
 


### PR DESCRIPTION
when loading attributes from information_schema, the `attribute.defaultValue` should be set as well to be compliant with the validation change introduced by https://github.com/cyjake/leoric/pull/262/files