### PR TITLE
fix:  mysql delete/remove/destroy with limit and orders

### DIFF
--- a/src/adapters/sequelize.js
+++ b/src/adapters/sequelize.js
@@ -308,7 +308,9 @@ module.exports = Bone => {
     // proxy to class.destroy({ individualHooks=false }) see https://github.com/sequelize/sequelize/blob/4063c2ab627ad57919d5b45cc7755f077a69fa5e/lib/model.js#L2895  before(after)BulkDestroy
     static async bulkDestroy(options = {}) {
       const { where, force } = options;
-      return await this.remove(where || {}, force, { ...options });
+      const spell = this._remove(where || {}, force, { ...options });
+      translateOptions(spell, options);
+      return spell;
     }
 
     // EXISTS

--- a/src/bone.js
+++ b/src/bone.js
@@ -789,7 +789,7 @@ class Bone {
       }, opts);
       return result;
     }
-    return await Model.remove(condition, forceDelete, { hooks: false, ...opts });
+    return await Model._remove(condition, forceDelete, opts);
   }
 
   /**
@@ -1454,6 +1454,24 @@ class Bone {
    * @return {Spell}
    */
   static remove(conditions, forceDelete = false, options) {
+    return this._remove(conditions, forceDelete, options);
+  }
+
+  /**
+   * private method for internal calling
+   * Remove any record that matches `conditions`.
+   * - If `forceDelete` is true, `DELETE` records from database permanently.
+   * - If not, update `deletedAt` attribute with current date.
+   * - If `forceDelete` isn't true and `deleteAt` isn't around, throw an Error.
+   * @example
+   * Post.remove({ title: 'Leah' })         // mark Post { title: 'Leah' } as deleted
+   * Post.remove({ title: 'Leah' }, true)   // delete Post { title: 'Leah' }
+   * Post.remove({}, true)                  // delete all data of posts
+   * @param {Object}  conditions
+   * @param {boolean} forceDelete
+   * @return {Spell}
+   */
+  static _remove(conditions, forceDelete = false, options) {
     const { deletedAt } = this.timestamps;
     if (forceDelete !== true && this.attributes[deletedAt]) {
       return Bone.update.call(this, conditions, { [deletedAt]: new Date() }, {

--- a/src/drivers/mysql/spellbook.js
+++ b/src/drivers/mysql/spellbook.js
@@ -75,4 +75,19 @@ module.exports = {
 
     return result;
   },
+  /**
+   * DELETE ... ORDER BY ...LIMIT
+   * @param {Spell} spell 
+   */
+  formatDelete(spell) {
+    const result = spellbook.formatDelete.call(this, spell);
+    const { rowCount, orders } = spell;
+    const chunks = [];
+
+    if (orders.length > 0) chunks.push(`ORDER BY ${this.formatOrders(spell, orders).join(', ')}`);
+    if (rowCount > 0) chunks.push(`LIMIT ${rowCount}`);
+    if (chunks.length > 0) result.sql += ` ${chunks.join(' ')}`;
+
+    return result;
+  }
 };


### PR DESCRIPTION
```js
Post.remove({ status: 1}, true).limit(n).order('id');
Post.remove({ status: 1}, false).limit(n).order('id');
// sequelize mode
Post.destroy({ where: { status: 1 }, limit: n, order: 'id' });
```