### PR TITLE
fix: previousChanges should check instance is new record or not while specific attributes' values were undefined

### DIFF
--- a/src/bone.js
+++ b/src/bone.js
@@ -183,7 +183,6 @@ class Bone {
     }
 
     if (args.length > 1) {
-      // execute validators
       this.#raw[name] = value instanceof Raw ? value : attribute.cast(value);
       this.#rawUnset.delete(name);
       return this;
@@ -371,7 +370,7 @@ class Bone {
    */
   previousChanges(name) {
     if (name != null) {
-      if (this.#rawUnset.has(name) || (this.#rawPrevious[name] === undefined && this.isNewRecord) || !this.hasAttribute(name)) return {};
+      if (this.#rawUnset.has(name) || this.#rawPrevious[name] === undefined || !this.hasAttribute(name)) return {};
       const value = this.attribute(name);
       const valueWas = this.#rawPrevious[name] == null ? null : this.#rawPrevious[name];
       if (util.isDeepStrictEqual(value, valueWas)) return {};
@@ -379,7 +378,7 @@ class Bone {
     }
     const result = {};
     for (const attrKey of Object.keys(this.constructor.attributes)) {
-      if (this.#rawUnset.has(attrKey) || (this.#rawPrevious[attrKey] === undefined && this.isNewRecord)) continue;
+      if (this.#rawUnset.has(attrKey) || this.#rawPrevious[attrKey] === undefined) continue;
       const value = this.attribute(attrKey);
       const valueWas = this.#rawPrevious[attrKey] == null ? null : this.#rawPrevious[attrKey];
       if (!util.isDeepStrictEqual(value, valueWas)) result[attrKey] = [ valueWas, value ];

--- a/src/bone.js
+++ b/src/bone.js
@@ -371,7 +371,7 @@ class Bone {
    */
   previousChanges(name) {
     if (name != null) {
-      if (this.#rawUnset.has(name) || this.#rawPrevious[name] === undefined || !this.hasAttribute(name)) return {};
+      if (this.#rawUnset.has(name) || (this.#rawPrevious[name] === undefined && this.isNewRecord) || !this.hasAttribute(name)) return {};
       const value = this.attribute(name);
       const valueWas = this.#rawPrevious[name] == null ? null : this.#rawPrevious[name];
       if (util.isDeepStrictEqual(value, valueWas)) return {};
@@ -379,7 +379,7 @@ class Bone {
     }
     const result = {};
     for (const attrKey of Object.keys(this.constructor.attributes)) {
-      if (this.#rawUnset.has(attrKey) || this.#rawPrevious[attrKey] === undefined) continue;
+      if (this.#rawUnset.has(attrKey) || (this.#rawPrevious[attrKey] === undefined && this.isNewRecord)) continue;
       const value = this.attribute(attrKey);
       const valueWas = this.#rawPrevious[attrKey] == null ? null : this.#rawPrevious[attrKey];
       if (!util.isDeepStrictEqual(value, valueWas)) result[attrKey] = [ valueWas, value ];

--- a/src/drivers/abstract/attribute.js
+++ b/src/drivers/abstract/attribute.js
@@ -123,7 +123,8 @@ class Attribute {
   }
 
   cast(value) {
-    return this.type.cast(value);
+    const castedValue = this.type.cast(value);
+    return castedValue == null? null : castedValue;
   }
 
   uncast(value, strict = true) {

--- a/test/integration/suite/basics.test.js
+++ b/test/integration/suite/basics.test.js
@@ -195,9 +195,12 @@ describe('=> Basic', () => {
       assert.deepEqual(post.previousChanges('title'), {});
       await post.save();
       assert.deepEqual(post.previousChanges('title'), {});
+      assert.deepEqual(post.previousChanges('authorId'), { });
       post.title = 'MHW';
+      post.authorId = 100;
       await post.save();
       assert.deepEqual(post.previousChanges('title'), { title: [ 'Untitled', 'MHW' ] });
+      assert.deepEqual(post.previousChanges('authorId'), { authorId: [ null, 100 ] });
       // should return {} if key does not exist
       assert.deepEqual(post.previousChanges('notExisted'), {});
     });
@@ -208,10 +211,11 @@ describe('=> Basic', () => {
       await post.save();
       assert.deepEqual(post.previousChanges(), {});
       post.title = 'MHW';
+      post.authorId = 100;
       const prevUpdatedAt = post.updatedAt;
       await sleep(10);
       await post.save();
-      assert.deepEqual(post.previousChanges(), { title: [ 'Untitled', 'MHW' ], updatedAt: [ prevUpdatedAt, post.updatedAt ] });
+      assert.deepEqual(post.previousChanges(), { authorId: [ null, 100 ], title: [ 'Untitled', 'MHW' ], updatedAt: [ prevUpdatedAt, post.updatedAt ] });
     });
 
     it('Bone.changes(key): raw VS rawSaved', async function () {

--- a/test/integration/suite/data_types.test.js
+++ b/test/integration/suite/data_types.test.js
@@ -118,6 +118,9 @@ describe('=> Data types - JSON', () => {
     assert.deepEqual(note3.meta, [ 1, 2, 3 ]);
     await note3.reload();
     assert.deepEqual(note3.meta, [ 1, 2, 3 ]);
+    assert.deepEqual(note3.body, null);
+    assert.deepEqual(note3.isPrivate, null);
+    assert.notEqual(note3.id, null);
 
     const note4 = await Note.findOne({ meta: { $like: '%1,2,3%' }});
     assert.deepEqual(note3.toJSON(), note4.toJSON());

--- a/test/unit/adapters/sequelize.test.js
+++ b/test/unit/adapters/sequelize.test.js
@@ -1043,6 +1043,13 @@ describe('=> Sequelize adapter', () => {
       updatedAt: post.updatedAt,
       createdAt: post.createdAt,
       wordCount: 0,
+      authorId: null,
+      content: null,
+      deletedAt: null,
+      extra: null,
+      settings: null,
+      summary: null,
+      thumb: null,
     });
     post.content = 'a';
     assert.deepEqual(post.previous(), {
@@ -1052,6 +1059,13 @@ describe('=> Sequelize adapter', () => {
       updatedAt: post.updatedAt,
       createdAt: post.createdAt,
       wordCount: 0,
+      authorId: null,
+      content: null,
+      deletedAt: null,
+      extra: null,
+      settings: null,
+      summary: null,
+      thumb: null,
     });
     const prevUpdatedAt = post.updatedAt;
     await post.update();
@@ -1062,6 +1076,13 @@ describe('=> Sequelize adapter', () => {
       updatedAt: prevUpdatedAt,
       createdAt: post.createdAt,
       wordCount: 0,
+      authorId: null,
+      content: null,
+      deletedAt: null,
+      extra: null,
+      settings: null,
+      summary: null,
+      thumb: null,
     });
   });
 


### PR DESCRIPTION
```js
// title: Untitled, authorId: undefined
const post = new Post({ title: 'Untitled' });
assert.deepEqual(post.previousChanges('title'), {});
assert.deepEqual(post.previousChanges('authorId'), {});
post.title = 'MHW';
// authorId was undefined
post.authorId = 100;
await post.save();
// post is not a new record now
assert.deepEqual(post.previousChanges('authorId'), { authorId: [ null, 100 ] });

```