### PR TITLE
fix:  upsert should set createdAt  by default while createdAt  not set 

### DIFF
--- a/src/drivers/abstract/spellbook.js
+++ b/src/drivers/abstract/spellbook.js
@@ -356,15 +356,14 @@ function formatInsert(spell) {
       }
     } else {
       for (const name in involved) {
-        // upsert should not update createdAt
-        if (updateOnDuplicate && createdAt && name === createdAt) continue;
         attributes.push(Model.attributes[name]);
       }
     }
 
     for (const entry of attributes) {
       columns.push(entry.columnName);
-      if (updateOnDuplicate && createdAt && entry.name === createdAt) continue;
+      if (updateOnDuplicate && createdAt && entry.name === createdAt 
+        && !(Array.isArray(updateOnDuplicate) && updateOnDuplicate.includes(createdAt))) continue;
       updateOnDuplicateColumns.push(entry.columnName);
     }
 
@@ -385,7 +384,6 @@ function formatInsert(spell) {
     }
     for (const name in sets) {
       const value = sets[name];
-      // upsert should not update createdAt
       columns.push(Model.unalias(name));
       if (value instanceof Raw) {
         values.push(SqlString.raw(value.value));

--- a/src/drivers/mysql/spellbook.js
+++ b/src/drivers/mysql/spellbook.js
@@ -49,7 +49,10 @@ module.exports = {
     const sets = [];
     // Make sure the correct LAST_INSERT_ID is returned.
     // - https://stackoverflow.com/questions/778534/mysql-on-duplicate-key-last-insert-id
-    sets.push(`${escapeId(primaryColumn)} = LAST_INSERT_ID(${escapeId(primaryColumn)})`);
+    // if insert attributes include primary column, `primaryKey = LAST_INSERT_ID(primaryKey)` is not need any more
+    if (!columns.includes(primaryColumn)) {
+      sets.push(`${escapeId(primaryColumn)} = LAST_INSERT_ID(${escapeId(primaryColumn)})`);
+    }
     sets.push(...columns.map(column => `${escapeId(column)}=VALUES(${escapeId(column)})`));
 
     return `ON DUPLICATE KEY UPDATE ${sets.join(', ')}`;

--- a/test/integration/postgres.test.js
+++ b/test/integration/postgres.test.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert').strict;
 const path = require('path');
+const sinon = require('sinon');
 
 const { connect, raw } = require('../..');
 
@@ -57,6 +58,28 @@ describe('=> upsert', function () {
       new Post({ id: 1, title: 'New Post', createdAt: raw('CURRENT_TIMESTAMP()'), updatedAt: raw('CURRENT_TIMESTAMP()') }).upsert().toString(),
       `INSERT INTO "articles" ("id", "title", "is_private", "word_count", "gmt_create", "gmt_modified") VALUES (1, 'New Post', false, 0, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()) ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "is_private"=EXCLUDED."is_private", "word_count"=EXCLUDED."word_count", "gmt_modified"=EXCLUDED."gmt_modified" RETURNING "id"`
     );
+    const date = new Date(2017, 11, 12);
+    const fakeDate = date.getTime();
+    sinon.useFakeTimers(fakeDate);
+    assert.equal(
+      new Post({ id: 1, title: 'New Post', createdAt: date, updatedAt: date }).upsert().toString(),
+      `INSERT INTO "articles" ("id", "title", "is_private", "word_count", "gmt_create", "gmt_modified") VALUES (1, 'New Post', false, 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "is_private"=EXCLUDED."is_private", "word_count"=EXCLUDED."word_count", "gmt_modified"=EXCLUDED."gmt_modified" RETURNING "id"`
+    );
+    assert.equal(
+      new Post({ title: 'New Post', createdAt: date, updatedAt: date }).upsert().toString(),
+      `INSERT INTO "articles" ("title", "is_private", "word_count", "gmt_create", "gmt_modified") VALUES ('New Post', false, 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON CONFLICT ("id") DO UPDATE SET "title"=EXCLUDED."title", "is_private"=EXCLUDED."is_private", "word_count"=EXCLUDED."word_count", "gmt_modified"=EXCLUDED."gmt_modified" RETURNING "id"`
+    );
+    // default set createdAt
+    assert.equal(
+      new Post({ id: 1, title: 'New Post' }).upsert().toString(),
+      `INSERT INTO "articles" ("id", "title", "is_private", "word_count", "gmt_create", "gmt_modified") VALUES (1, 'New Post', false, 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "is_private"=EXCLUDED."is_private", "word_count"=EXCLUDED."word_count", "gmt_modified"=EXCLUDED."gmt_modified" RETURNING "id"`
+    );
+
+    assert.equal(
+      Post.upsert({ title: 'New Post' }).toSqlString(),
+      `INSERT INTO "articles" ("title", "is_private", "word_count", "gmt_create", "gmt_modified") VALUES ('New Post', false, 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON CONFLICT ("id") DO UPDATE SET "title"=EXCLUDED."title", "is_private"=EXCLUDED."is_private", "word_count"=EXCLUDED."word_count", "gmt_modified"=EXCLUDED."gmt_modified" RETURNING "id"`
+    );
+
   });
 
   it('upsert returning multiple columns', function() {

--- a/test/unit/spell.test.js
+++ b/test/unit/spell.test.js
@@ -55,9 +55,35 @@ describe('=> Spell', function() {
 
   it('insert ... on duplicate key update', function() {
     const date = new Date(2017, 11, 12);
+    const fakeDate = date.getTime();
+    sinon.useFakeTimers(fakeDate);
     assert.equal(
       new Post({ id: 1, title: 'New Post', createdAt: date, updatedAt: date }).upsert().toString(),
-      "INSERT INTO `articles` (`id`, `is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (1, 0, 'New Post', 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON DUPLICATE KEY UPDATE `id` = LAST_INSERT_ID(`id`), `id`=VALUES(`id`), `is_private`=VALUES(`is_private`), `title`=VALUES(`title`), `word_count`=VALUES(`word_count`), `gmt_modified`=VALUES(`gmt_modified`)"
+      "INSERT INTO `articles` (`id`, `is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (1, 0, 'New Post', 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON DUPLICATE KEY UPDATE `id`=VALUES(`id`), `is_private`=VALUES(`is_private`), `title`=VALUES(`title`), `word_count`=VALUES(`word_count`), `gmt_modified`=VALUES(`gmt_modified`)"
+    );
+    assert.equal(
+      new Post({ title: 'New Post', createdAt: date, updatedAt: date }).upsert().toString(),
+      "INSERT INTO `articles` (`is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (0, 'New Post', 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON DUPLICATE KEY UPDATE `id` = LAST_INSERT_ID(`id`), `is_private`=VALUES(`is_private`), `title`=VALUES(`title`), `word_count`=VALUES(`word_count`), `gmt_modified`=VALUES(`gmt_modified`)"
+    );
+    // default set createdAt
+    assert.equal(
+      new Post({ id: 1, title: 'New Post' }).upsert().toString(),
+      "INSERT INTO `articles` (`id`, `is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (1, 0, 'New Post', 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON DUPLICATE KEY UPDATE `id`=VALUES(`id`), `is_private`=VALUES(`is_private`), `title`=VALUES(`title`), `word_count`=VALUES(`word_count`), `gmt_modified`=VALUES(`gmt_modified`)"
+    );
+
+    assert.equal(
+      Post.upsert({ title: 'New Post' }).toSqlString(),
+      "INSERT INTO `articles` (`is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (0, 'New Post', 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON DUPLICATE KEY UPDATE `id` = LAST_INSERT_ID(`id`), `is_private`=VALUES(`is_private`), `title`=VALUES(`title`), `word_count`=VALUES(`word_count`), `gmt_modified`=VALUES(`gmt_modified`)"
+    );
+
+    assert.equal(
+      new Book({ name: 'Dark', price: 100 }).upsert().toSqlString(),
+      "INSERT INTO `books` (`name`, `price`, `gmt_create`, `gmt_modified`) VALUES ('Dark', 100, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON DUPLICATE KEY UPDATE `isbn` = LAST_INSERT_ID(`isbn`), `name`=VALUES(`name`), `price`=VALUES(`price`), `gmt_modified`=VALUES(`gmt_modified`)"
+    );
+
+    assert.equal(
+      new Book({ isbn: 10000, name: 'Dark', price: 100 }).upsert().toSqlString(),
+      "INSERT INTO `books` (`isbn`, `name`, `price`, `gmt_create`, `gmt_modified`) VALUES (10000, 'Dark', 100, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON DUPLICATE KEY UPDATE `isbn`=VALUES(`isbn`), `name`=VALUES(`name`), `price`=VALUES(`price`), `gmt_modified`=VALUES(`gmt_modified`)"
     );
   });
 
@@ -729,7 +755,7 @@ describe('=> Spell', function() {
   it('upsert with raw sql', function () {
     assert.equal(
       new Post({ id: 1, title: 'New Post', createdAt: raw('CURRENT_TIMESTAMP()'), updatedAt: raw('CURRENT_TIMESTAMP()') }).upsert().toString(),
-      "INSERT INTO `articles` (`id`, `is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (1, 0, 'New Post', 0, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()) ON DUPLICATE KEY UPDATE `id` = LAST_INSERT_ID(`id`), `id`=VALUES(`id`), `is_private`=VALUES(`is_private`), `title`=VALUES(`title`), `word_count`=VALUES(`word_count`), `gmt_modified`=VALUES(`gmt_modified`)"
+      "INSERT INTO `articles` (`id`, `is_private`, `title`, `word_count`, `gmt_create`, `gmt_modified`) VALUES (1, 0, 'New Post', 0, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()) ON DUPLICATE KEY UPDATE `id`=VALUES(`id`), `is_private`=VALUES(`is_private`), `title`=VALUES(`title`), `word_count`=VALUES(`word_count`), `gmt_modified`=VALUES(`gmt_modified`)"
     );
   });
 


### PR DESCRIPTION
```js
Post.upser({ title: 'yes' });
// INSERT INTO `posts` (`title`,  `created_at`, `updated_at`) VALUES ('yes', `currentTime`, `currentTime`) ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `updated_at` = VALUES(`updated_at`)
// set created_at in fields but not `ON DUPLICATE KEY UPDATE` options

Post.upsert({ title: 'yes', createdAt: 'currentTime' });
// INSERT INTO `posts` (`title`,  `created_at`, `updated_at`) VALUES ('yes', `currentTime`, `currentTime`) ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `created_at` = VALUES(`created_at`), `updated_at` = VALUES(`updated_at`)

```