### PR TITLE
feat: add types for realm

### DIFF
--- a/test/start.sh
+++ b/test/start.sh
@@ -29,7 +29,7 @@ function integration {
 ##
 # definition type tests
 function dts {
-  npx tsc
+  npx tsc --esModuleInterop
   run "$(ls test/types/*.test.js)";
 }
 

--- a/test/start.sh
+++ b/test/start.sh
@@ -29,7 +29,7 @@ function integration {
 ##
 # definition type tests
 function dts {
-  npx tsc --esModuleInterop
+  npx tsc
   run "$(ls test/types/*.test.js)";
 }
 

--- a/test/types/realm.test.ts
+++ b/test/types/realm.test.ts
@@ -36,6 +36,36 @@ describe('=> Realm (TypeScript)', function () {
   });
 
   describe('realm.sync(options)', async function() {
+    it('options should be optional', async function() {
+      assert.doesNotThrow(async () => {
+        const { STRING } = realm.DataTypes;
+        realm.define('User', { name: STRING });
+        await realm.sync();
+      });
+    });
 
+    it('`force` can be passed individually', async function() {
+      assert.doesNotThrow(async () => {
+        const { STRING } = realm.DataTypes;
+        realm.define('User', { name: STRING });
+        await realm.sync({ force: true });
+      });
+    });
+
+    it('`alter` can be passed individually', async function() {
+      assert.doesNotThrow(async () => {
+        const { STRING } = realm.DataTypes;
+        realm.define('User', { name: STRING });
+        await realm.sync({ alter: true });
+      });
+    });
+
+    it('`force` and `alter` can be passed together', async function() {
+      assert.doesNotThrow(async () => {
+        const { STRING } = realm.DataTypes;
+        realm.define('User', { name: STRING });
+        await realm.sync({ force: true, alter: true });
+      });
+    });
   });
 });

--- a/test/types/realm.test.ts
+++ b/test/types/realm.test.ts
@@ -1,0 +1,41 @@
+import { strict as assert } from 'assert';
+import Realm from '../..';
+
+describe('=> Realm (TypeScript)', function () {
+  let realm: Realm;
+  before(function() {
+    realm = new Realm({
+      port: process.env.MYSQL_PORT,
+      database: 'leoric',
+      subclass: true,
+    });
+  });
+
+  describe('realm.define(name, attributes, options, descriptors)', async function() {
+    it('options and descriptors should be optional', async function() {
+      assert.doesNotThrow(function() {
+        const { STRING } = realm.DataTypes;
+        realm.define('User', { name: STRING });
+      });
+    });
+
+    it('can customize attributes with descriptors', async function() {
+      const { STRING } = realm.DataTypes;
+      realm.define('User', { name: STRING }, {}, {
+        get name() {
+          return this.attribute('name').replace(/^([a-z])/, function(m, chr) {
+            return chr.toUpperCase();
+          });
+        },
+        set name(value) {
+          if (typeof value !== 'string') throw new Error('unexpected name' + value);
+          this.attribute('name', value);
+        }
+      });
+    });
+  });
+
+  describe('realm.sync(options)', async function() {
+
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2018",
     "moduleResolution": "Node",
     "module": "CommonJS",
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "esModuleInterop": true
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -597,9 +597,11 @@ export interface ConnectOptions {
   client?: 'mysql' | 'mysql2' | 'pg' | 'sqlite3' | '@journeyapps/sqlcipher';
   dialect?: 'mysql' | 'postgres' | 'sqlite';
   host?: string;
+  port?: number | string;
   user?: string;
   database: string;
   models?: string | (typeof Bone)[];
+  subclass?: boolean;
 }
 
 interface InitOptions {
@@ -631,6 +633,7 @@ interface RawQueryOptions {
 
 export default class Realm {
   Bone: typeof Bone;
+  DataTypes: typeof DataType;
   driver: Driver;
   models: Record<string, Bone>;
 
@@ -638,7 +641,7 @@ export default class Realm {
 
   define(
     name: string,
-    attributes: Record<string, AttributeMeta>,
+    attributes: Record<string, DataTypes<DataType> | AttributeMeta>,
     options?: InitOptions,
     descriptors?: Record<string, Function>,
   ): Bone;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -593,7 +593,7 @@ export class Bone {
   toObject(): InstanceValues<this>;
 }
 
-interface ConnectOptions {
+export interface ConnectOptions {
   client?: 'mysql' | 'mysql2' | 'pg' | 'sqlite3' | '@journeyapps/sqlcipher';
   dialect?: 'mysql' | 'postgres' | 'sqlite';
   host?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -612,6 +612,11 @@ interface InitOptions {
   };
 }
 
+interface SyncOptions {
+  force?: boolean;
+  alter?: boolean;
+}
+
 type RawSql = {
   __raw: true,
   value: string,
@@ -634,8 +639,8 @@ export default class Realm {
   define(
     name: string,
     attributes: Record<string, AttributeMeta>,
-    options: InitOptions,
-    descriptors: Record<string, Function>,
+    options?: InitOptions,
+    descriptors?: Record<string, Function>,
   ): Bone;
 
   raw(sql: string): RawSql;
@@ -646,6 +651,8 @@ export default class Realm {
 
   transaction(callback: GeneratorFunction): Promise<void>;
   transaction(callback: (connection: Connection) => Promise<void>): Promise<void>;
+
+  sync(options?: SyncOptions): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
- Make the last two parameters optional of `Realm.prototype.define()`.
- Add `sync` method signature.