### PR TITLE
fix: add missing `password` field for `ConnectOptions`

### DIFF
--- a/test/types/realm.test.ts
+++ b/test/types/realm.test.ts
@@ -21,7 +21,7 @@ describe('=> Realm (TypeScript)', function () {
 
     it('can customize attributes with descriptors', async function() {
       const { STRING } = realm.DataTypes;
-      realm.define('User', { name: STRING }, {}, {
+      const User = realm.define('User', { name: STRING }, {}, {
         get name() {
           return this.attribute('name').replace(/^([a-z])/, function(m, chr) {
             return chr.toUpperCase();
@@ -32,6 +32,8 @@ describe('=> Realm (TypeScript)', function () {
           this.attribute('name', value);
         }
       });
+      // User.findOne should exists
+      assert(User.findOne);
     });
   });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -599,6 +599,7 @@ export interface ConnectOptions {
   host?: string;
   port?: number | string;
   user?: string;
+  password?: string;
   database: string;
   models?: string | (typeof Bone)[];
   subclass?: boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -645,7 +645,7 @@ export default class Realm {
     attributes: Record<string, DataTypes<DataType> | AttributeMeta>,
     options?: InitOptions,
     descriptors?: Record<string, Function>,
-  ): Bone;
+  ): typeof Bone;
 
   raw(sql: string): RawSql;
 


### PR DESCRIPTION
- Add missing `password` for `ConnectOptions`.
- Fix the return type of `Realm.prototype.define()`.