### PR TITLE
fix: tddl gives misleading information_schema.columns.table_name

### DIFF
--- a/src/realm.js
+++ b/src/realm.js
@@ -75,7 +75,7 @@ async function loadModels(Spine, models, opts) {
   const schemaInfo = await Spine.driver.querySchemaInfo(database, tables);
 
   for (const model of models) {
-    const columns = schemaInfo[model.physicTable];
+    const columns = schemaInfo[model.physicTable] || schemaInfo[model.table];
     if (!model.attributes) initAttributes(model, columns);
     model.load(columns);
     Spine.models[model.name] = model;


### PR DESCRIPTION
```sql
MySQL [CENTRAL_APP]> SELECT table_name FROM information_schema.columns WHERE table_schema = 'CENTRAL_APP' AND table_name in ('central_creations_logic_0000') LIMIT 1;
+-------------------------+
| table_name              |
+-------------------------+
| central_creations_logic |
+-------------------------+
1 row in set (0.03 sec)
```