### PR TITLE
fix: raw query should format replacements with extra blank

### DIFF
--- a/src/realm.js
+++ b/src/realm.js
@@ -195,7 +195,7 @@ class Realm {
         throw new Error(`unable to replace: ${key}`);
       }
       values.push(replacements[key]);
-      return '?';
+      return ' ?';
     });
 
     const { rows, ...restRes } = await this.driver.query(query, values, opts);

--- a/test/unit/realm.test.js
+++ b/test/unit/realm.test.js
@@ -332,10 +332,11 @@ describe('=> Realm', () => {
         const createdAt = new Date();
         const post = await Post.create({ title: 'title', authorId: 1, createdAt });
         const post1 = await Post.create({ title: 'title1', authorId: 2, createdAt });
-        const { rows } = await realm.query('SELECT * FROM articles where title = :title AND author_id = :authorId', {
+        const { rows } = await realm.query('SELECT * FROM articles where title = :title AND author_id = :authorId LIMIT :limit', {
           replacements: {
             title: post1.title,
-            authorId: 2
+            authorId: 2,
+            limit: 1,
           },
           model: Post
         });


### PR DESCRIPTION
```js
 const { rows } = await realm.query('SELECT * FROM articles where title = :title AND author_id = :authorId LIMIT :limit', {
    replacements: {
      title: post1.title,
      authorId: 2,
      limit: 1,
    },
  });
// actual: SELECT * FROM articles where title ='title1' AND author_id =2 LIMIT1 # may cause SQL syntax error
// expect: SELECT * FROM articles where title = 'title1' AND author_id = 2 LIMIT 1
```