### PR TITLE
fix: primaryKey in upsert values should be validate in sqlite and postgres

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,9 @@
     "node": true,
     "es6": true
   },
+  "plugins": [
+    "no-only-tests"
+  ],
   "rules": {
     "curly": [2, "multi-line"],
     "consistent-return": 0,
@@ -22,6 +25,11 @@
     "no-unused-vars": [2, { "vars": "all", "args": "none", "ignoreRestSiblings": true }],
     "no-shadow": 2,
     "keyword-spacing": "error",
-    "eol-last": "error"
+    "eol-last": "error",
+    "prefer-const": "error",
+    "no-only-tests/no-only-tests": "error",
+    "no-trailing-spaces": "error",
+    "space-before-blocks": "error",
+    "space-in-parens": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/node": "^16.10.1",
     "dayjs": "^1.10.3",
     "eslint": "^7.20.0",
+    "eslint-plugin-no-only-tests": "^3.0.0",
     "expect.js": "^0.3.1",
     "jsdoc": "^3.6.3",
     "mocha": "^8.2.1",

--- a/src/adapters/sequelize.js
+++ b/src/adapters/sequelize.js
@@ -65,7 +65,7 @@ const setScopeToSpell = (scope) => (spell) => {
  * @returns {Object}
  */
 function mergeScope(scopes) {
-  let merged = {};
+  const merged = {};
   for (const scope of scopes) {
     if (scope.where) {
       merged.where = Object.assign({}, merged.where, scope.where);
@@ -227,7 +227,7 @@ module.exports = Bone => {
       }
 
       const { where } = options;
-      let spell = this._find(where, options)[`$${func}`](name);
+      const spell = this._find(where, options)[`$${func}`](name);
       if (options.paranoid === false) return spell.unparanoid;
       return spell;
     }
@@ -262,9 +262,9 @@ module.exports = Bone => {
 
     /**
      * see https://github.com/sequelize/sequelize/blob/a729c4df41fa3a58fbecaf879265d2fb73d80e5f/src/model.js#L2299
-     * @param {Array<Object>} valueSets 
-     * @param {Object} options 
-     * @returns 
+     * @param {Array<Object>} valueSets
+     * @param {Object} options
+     * @returns
      */
     static bulkBuild(valueSets, options = {}) {
       if (!valueSets.length) return [];
@@ -333,7 +333,7 @@ module.exports = Bone => {
     // static drop() {}
 
     static findAll(options = {}) {
-      let spell = this._find({}, filterOptions(options));
+      const spell = this._find({}, filterOptions(options));
       translateOptions(spell, options);
       if (options.paranoid === false) return spell.unparanoid;
       return spell;

--- a/src/bone.js
+++ b/src/bone.js
@@ -102,7 +102,7 @@ function valuesValidate(values, attributes, ctx) {
     const value = values[valueKey];
     if (value == null && defaultValue == null) {
       if (allowNull === false) throw new LeoricValidateError('notNull', name);
-      if ((allowNull === true || allowNull === undefined) && validate.notNull === undefined ) continue;
+      if ((allowNull === true || allowNull === undefined) && validate.notNull === undefined) continue;
     }
     if (!validate) continue;
     for (const key in validate) {
@@ -700,7 +700,7 @@ class Bone {
   async _update(values, options = {}) {
     const Model = this.constructor;
     const { attributes, primaryKey, shardingKey } = Model;
-    let changes = {};
+    const changes = {};
     if (values == null) {
       for (const name in attributes) {
         if (this.changed(name)) changes[name] = this.attribute(name);
@@ -728,7 +728,7 @@ class Bone {
     if (attributes[updatedAt] && !changes[updatedAt] && !changes[deletedAt] && !options.silent) {
       changes[updatedAt] = new Date();
     }
-    if (options.validate !== false ) {
+    if (options.validate !== false) {
       this._validateAttributes(changes);
     }
     const spell = new Spell(Model, options).$where(where).$update(changes);
@@ -911,10 +911,9 @@ class Bone {
     const { attributes } = Model;
     for (const key in attributes) {
       const attribute = attributes[key];
-      if (attribute.primaryKey) continue;
       if (values[key] == null && attribute.defaultValue != null) {
         data[key] = attribute.defaultValue;
-      } else if (values[key] !== undefined){
+      } else if (values[key] !== undefined) {
         data[key] = values[key];
       }
     }
@@ -1668,7 +1667,7 @@ class Bone {
       if (force) {
         await driver.dropTable(table);
         await driver.createTable(table, attributes);
-      } else if (alter){
+      } else if (alter) {
         await driver.alterTable(table, compare(attributes, columnMap));
       } else {
         console.warn('[synchronize_fail] %s couldn\'t be synchronized, please use force or alter to specify execution', this.name);

--- a/src/drivers/abstract/index.js
+++ b/src/drivers/abstract/index.js
@@ -36,8 +36,8 @@ class AbstractDriver {
 
   /**
    * query with spell
-   * @param {Spell} spell 
-   * @returns 
+   * @param {Spell} spell
+   * @returns
    */
   async cast(spell) {
     const { sql, values } = this.format(spell);
@@ -47,9 +47,9 @@ class AbstractDriver {
 
   /**
    * raw query
-   * @param {object|string} query 
-   * @param {object | array} values 
-   * @param {object} opts 
+   * @param {object|string} query
+   * @param {object | array} values
+   * @param {object} opts
    */
   async query(query, values, opts) {
     throw new Error('unimplemented!');
@@ -57,7 +57,7 @@ class AbstractDriver {
 
   /**
    * disconnect manually
-   * @param {Function} callback 
+   * @param {Function} callback
    */
   async disconnect(callback) {
     debug('[disconnect] called');
@@ -69,8 +69,8 @@ class AbstractDriver {
 
   /**
    * use spellbook to format spell
-   * @param {Spell} spell 
-   * @returns 
+   * @param {Spell} spell
+   * @returns
    */
   format(spell) {
     return this.spellbook.format(spell);

--- a/src/realm.js
+++ b/src/realm.js
@@ -102,12 +102,12 @@ const rReplacementKey = /\s:(\w+)\b/g;
 
 class Realm {
   constructor(opts = {}) {
-    let { 
-      dialect = 'mysql', 
-      dialectModulePath, 
-      client = dialectModulePath, 
-      database = opts.db || opts.storage, 
-      driver: CustomDriver, 
+    const {
+      dialect = 'mysql',
+      dialectModulePath,
+      client = dialectModulePath,
+      database = opts.db || opts.storage,
+      driver: CustomDriver,
       ...restOpts
     } = opts;
     const Spine = createSpine(opts);
@@ -217,7 +217,7 @@ class Realm {
     const { rows, ...restRes } = await this.driver.query(query, values, opts);
     const results = [];
 
-    if (rows && rows.length && opts.model && opts.model.prototype instanceof this.Bone) {
+    if (rows && rows.length && opts.model && isBone(opts.model)) {
       const { attributeMap } = opts.model;
 
       for (const data of rows) {

--- a/test/integration/postgres.test.js
+++ b/test/integration/postgres.test.js
@@ -53,6 +53,7 @@ describe('=> Date functions (postgres)', function() {
 
 describe('=> upsert', function () {
   const Post = require('../models/post');
+  const User = require('../models/user');
 
   it('upsert', function() {
     assert.equal(
@@ -79,6 +80,21 @@ describe('=> upsert', function () {
     assert.equal(
       Post.upsert({ title: 'New Post' }).toSqlString(),
       `INSERT INTO "articles" ("title", "is_private", "word_count", "gmt_create", "gmt_modified") VALUES ('New Post', false, 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON CONFLICT ("id") DO UPDATE SET "title"=EXCLUDED."title", "is_private"=EXCLUDED."is_private", "word_count"=EXCLUDED."word_count", "gmt_modified"=EXCLUDED."gmt_modified" RETURNING "id"`
+    );
+
+    assert.equal(
+      Post.upsert({ title: 'New Post', id: 1 }).toSqlString(),
+      `INSERT INTO "articles" ("id", "title", "is_private", "word_count", "gmt_create", "gmt_modified") VALUES (1, 'New Post', false, 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "is_private"=EXCLUDED."is_private", "word_count"=EXCLUDED."word_count", "gmt_modified"=EXCLUDED."gmt_modified" RETURNING "id"`
+    );
+
+    assert.equal(
+      User.upsert({ email: 'dk@souls.com', nickname: 'Yhorm' }).toSqlString(),
+      `INSERT INTO "users" ("email", "nickname", "status", "level", "gmt_create") VALUES ('dk@souls.com', 'Yhorm', 1, 1, '2017-12-12 00:00:00.000') ON CONFLICT ("email") DO UPDATE SET "email"=EXCLUDED."email", "nickname"=EXCLUDED."nickname", "status"=EXCLUDED."status", "level"=EXCLUDED."level" RETURNING "id"`
+    );
+
+    assert.equal(
+      User.upsert({ email: 'dk@souls.com', nickname: 'Yhorm', id: 1 }).toSqlString(),
+      `INSERT INTO "users" ("id", "email", "nickname", "status", "level", "gmt_create") VALUES (1, 'dk@souls.com', 'Yhorm', 1, 1, '2017-12-12 00:00:00.000') ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "email"=EXCLUDED."email", "nickname"=EXCLUDED."nickname", "status"=EXCLUDED."status", "level"=EXCLUDED."level" RETURNING "id"`
     );
 
   });

--- a/test/integration/sqlite.test.js
+++ b/test/integration/sqlite.test.js
@@ -59,6 +59,7 @@ describe('=> Table definitions (sqlite)', () => {
 
 describe('=> upsert (sqlite)', function () {
   const Post = require('../models/post');
+  const User = require('../models/user');
 
   it('upsert', function() {
     assert.equal(
@@ -85,6 +86,21 @@ describe('=> upsert (sqlite)', function () {
     assert.equal(
       Post.upsert({ title: 'New Post' }).toSqlString(),
       `INSERT INTO "articles" ("title", "is_private", "word_count", "gmt_create", "gmt_modified") VALUES ('New Post', false, 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON CONFLICT ("id") DO UPDATE SET "title"=EXCLUDED."title", "is_private"=EXCLUDED."is_private", "word_count"=EXCLUDED."word_count", "gmt_modified"=EXCLUDED."gmt_modified"`
+    );
+
+    assert.equal(
+      Post.upsert({ title: 'New Post', id: 1 }).toSqlString(),
+      `INSERT INTO "articles" ("id", "title", "is_private", "word_count", "gmt_create", "gmt_modified") VALUES (1, 'New Post', false, 0, '2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000') ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "title"=EXCLUDED."title", "is_private"=EXCLUDED."is_private", "word_count"=EXCLUDED."word_count", "gmt_modified"=EXCLUDED."gmt_modified"`
+    );
+
+    assert.equal(
+      User.upsert({ email: 'dk@souls.com', nickname: 'Yhorm' }).toSqlString(),
+      `INSERT INTO "users" ("email", "nickname", "status", "level", "gmt_create") VALUES ('dk@souls.com', 'Yhorm', 1, 1, '2017-12-12 00:00:00.000') ON CONFLICT ("email") DO UPDATE SET "email"=EXCLUDED."email", "nickname"=EXCLUDED."nickname", "status"=EXCLUDED."status", "level"=EXCLUDED."level"`
+    );
+
+    assert.equal(
+      User.upsert({ email: 'dk@souls.com', nickname: 'Yhorm', id: 1 }).toSqlString(),
+      `INSERT INTO "users" ("id", "email", "nickname", "status", "level", "gmt_create") VALUES (1, 'dk@souls.com', 'Yhorm', 1, 1, '2017-12-12 00:00:00.000') ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "email"=EXCLUDED."email", "nickname"=EXCLUDED."nickname", "status"=EXCLUDED."status", "level"=EXCLUDED."level"`
     );
   });
 });

--- a/test/integration/suite/basics.test.js
+++ b/test/integration/suite/basics.test.js
@@ -84,7 +84,7 @@ describe('=> Basic', () => {
 
     it('bone.hasAttribute(key) should work with VIRTUAL', async function() {
       await User.create({ nickname: 'yes', email: 'ee@1.com' });
-      let user = await User.first.select('nickname');
+      const user = await User.first.select('nickname');
       expect(user.hasAttribute('nickname')).to.be(true);
       expect(user.hasAttribute('NotExist')).to.be(false);
       expect(user.hasAttribute()).to.be(false);
@@ -450,7 +450,7 @@ describe('=> Basic', () => {
       const sql_mode = sql_mode_res.rows[0].sql_mode;
       await Post.driver.query('set SESSION sql_mode=""');
       const post = await Post.create({ title: 'Lothric' });
-      await Post.driver.query('UPDATE articles SET gmt_create = ? where id = ?', [ '0000-00-00 00:00:00', post.id ] );
+      await Post.driver.query('UPDATE articles SET gmt_create = ? where id = ?', [ '0000-00-00 00:00:00', post.id ]);
       await post.reload();
       assert.deepEqual(post.createdAt.toString(), 'Invalid Date');
       post.title = 'halo';
@@ -1160,6 +1160,16 @@ describe('=> Basic', () => {
           assert.equal(user.attribute('status'), 1);
           assert.equal(user.level, 1);
         });
+
+        it('Bone.upsert should work with primaryKey', async () => {
+          await User.upsert({ email: 'yes@yes', nickname: 'halo' });
+          const user = await User.findOne({ nickname: 'halo' });
+          assert.equal(user.nickname, 'halo');
+          await User.upsert({ id: user.id, nickname: 'Yhorm', email: 'yes1@yes', });
+          await user.reload();
+          assert.equal(user.nickname, 'Yhorm');
+          assert.equal(user.email, 'yes1@yes');
+        });
       });
     });
 
@@ -1241,7 +1251,7 @@ describe('=> Basic', () => {
       let post4 = await Post.findOne('id = ?', posts[3].id).unparanoid;
       assert(post4.deletedAt);
 
-      deleteCount = await Post.remove( {
+      deleteCount = await Post.remove({
         word_count: {
             $gte: 0
           }
@@ -1390,11 +1400,11 @@ describe('=> Basic', () => {
       });
 
       assert.equal(await User.count(), 2);
-      let p1 = await User.findOne({ email: 'hello@h1.com' });
+      const p1 = await User.findOne({ email: 'hello@h1.com' });
       assert.equal(p1.nickname, 'TYRAEL');
       const p1CreatedAt = p1.createdAt;
       assert(p1CreatedAt);
-      let p2 = await User.findOne({ email: 'hello1@h1.com' });
+      const p2 = await User.findOne({ email: 'hello1@h1.com' });
       assert.equal(p2.nickname, 'LEAH');
       const p2CreatedAt = p2.createdAt;
       assert(p2CreatedAt);
@@ -1406,11 +1416,11 @@ describe('=> Basic', () => {
         updateOnDuplicate: [ 'nickname', 'status' ]
       });
 
-      let p1Updated1 = await User.findOne({ email: 'hello@h1.com' });
+      const p1Updated1 = await User.findOne({ email: 'hello@h1.com' });
       assert.equal(p1Updated1.nickname, 'TYRAEL1');
       const p1Updated1CreatedAt = p1Updated1.createdAt;
       assert.deepEqual(p1Updated1CreatedAt, p1CreatedAt);
-      let p2Updated1 = await User.findOne({ email: 'hello1@h1.com' });
+      const p2Updated1 = await User.findOne({ email: 'hello1@h1.com' });
       assert.equal(p2Updated1.nickname, 'LEAH1');
       const p2Updated1CreatedAt = p2Updated1.createdAt;
       assert.deepEqual(p2Updated1CreatedAt, p2CreatedAt);
@@ -1422,11 +1432,11 @@ describe('=> Basic', () => {
         updateOnDuplicate: [ 'nickname', 'status', 'createdAt' ]
       });
 
-      let p1Updated2 = await User.findOne({ email: 'hello@h1.com' });
+      const p1Updated2 = await User.findOne({ email: 'hello@h1.com' });
       assert.equal(p1Updated2.nickname, 'TYRAEL2');
       const p1Updated2CreatedAt = p1Updated2.createdAt;
       assert.notDeepEqual(p1Updated2CreatedAt, p1CreatedAt);
-      let p2Updated2 = await User.findOne({ email: 'hello1@h1.com' });
+      const p2Updated2 = await User.findOne({ email: 'hello1@h1.com' });
       assert.equal(p2Updated2.nickname, 'LEAH2');
       const p2Updated2CreatedAt = p2Updated2.createdAt;
       assert.notDeepEqual(p2Updated2CreatedAt, p2CreatedAt);

--- a/test/unit/adapters/sequelize.test.js
+++ b/test/unit/adapters/sequelize.test.js
@@ -484,7 +484,7 @@ describe('=> Sequelize adapter', () => {
     });
 
     it('Model.findAll({ group: string })', async () => {
-      let result = await Post.findAll({
+      const result = await Post.findAll({
         attributes: 'count(*) AS count',
         group: 'title',
         order: [[ 'title', 'desc' ]],
@@ -496,7 +496,7 @@ describe('=> Sequelize adapter', () => {
     });
 
     it('Model.findAll({ group: [] })', async () => {
-      let result = await Post.findAll({
+      const result = await Post.findAll({
         attributes: 'count(*) AS count',
         group: [ 'title' ],
         order: [[ 'title', 'desc' ]],
@@ -518,7 +518,7 @@ describe('=> Sequelize adapter', () => {
     });
 
     it('Model.findAll({ having: string })', async () => {
-      let result = await Post.findAll({
+      const result = await Post.findAll({
         attributes: 'count(*) AS count',
         group: 'title',
         order: [[ 'title', 'desc' ]],
@@ -530,7 +530,7 @@ describe('=> Sequelize adapter', () => {
     });
 
     it('Model.findAll({ having: rawObject })', async () => {
-      let result = await Post.findAll({
+      const result = await Post.findAll({
         attributes: 'count(*) AS count',
         group: 'title',
         order: [[ 'title', 'desc' ]],
@@ -1423,7 +1423,7 @@ describe('Model.init with getterMethods and setterMethods', () => {
   const key = '12Tvzr3p67VC61jMw54rIHu1545x4Tlx';
   const iv = 'iceiceiceiceicei';
 
-  function encrypt(text){
+  function encrypt(text) {
     if (!text) return null;
     const cipher = crypto.createCipheriv(algorithm, key, iv);
     let crypted = cipher.update(text,'utf8','hex');
@@ -1431,7 +1431,7 @@ describe('Model.init with getterMethods and setterMethods', () => {
     return crypted;
   }
 
-  function decrypt(text){
+  function decrypt(text) {
     if (!text) return null;
     const decipher = crypto.createCipheriv(algorithm, key, iv);
     let dec = decipher.update(text,'hex','utf8');

--- a/test/unit/realm.test.js
+++ b/test/unit/realm.test.js
@@ -1072,7 +1072,7 @@ describe('=> Realm', () => {
       assert.equal(Post.attributes.updatedAt.columnName, 'gmt_modified');
       assert.equal(Post.attributes.deletedAt.columnName, 'gmt_deleted');
     });
-    
+
     it('should auto assign driver if not exist', async function () {
 
       class User extends Bone {}


### PR DESCRIPTION
```js
User.upsert({ email: 'dk@souls.com', nickname: 'Yhorm' }).toSqlString();
// email is unique, when values not contains primaryKey, it should be ON CONFLICT ("email")
// SQL: INSERT INTO "users" ("email", "nickname", "status", "level", "gmt_create") VALUES ('dk@souls.com', 'Yhorm', 1, 1, '2017-12-12 00:00:00.000') ON CONFLICT ("email") DO UPDATE SET "email"=EXCLUDED."email", "nickname"=EXCLUDED."nickname", "status"=EXCLUDED."status", "level"=EXCLUDED."level"

User.upsert({ email: 'dk@souls.com', nickname: 'Yhorm', id: 1 }).toSqlString();
//  when values contains primaryKey, it should be ON CONFLICT ("id")
// INSERT INTO "users" ("id", "email", "nickname", "status", "level", "gmt_create") VALUES (1, 'dk@souls.com', 'Yhorm', 1, 1, '2017-12-12 00:00:00.000') ON CONFLICT ("id") DO UPDATE SET "id"=EXCLUDED."id", "email"=EXCLUDED."email", "nickname"=EXCLUDED."nickname", "status"=EXCLUDED."status", "level"=EXCLUDED."level"
```