### PR TITLE
fix: INTEGER like data type and STRING extra options didn't work in polymorphism, fix decorators ColumnOptions.type to support invokable

### DIFF
--- a/src/data_types.ts
+++ b/src/data_types.ts
@@ -116,10 +116,12 @@ class INTEGER extends DataType {
   unsigned?: boolean;
   zerofill?: boolean;
 
-  constructor(dataLength?: number) {
+  constructor(dataLength?: number, unsigned?: boolean, zerofill?: boolean) {
     super();
     this.dataLength = dataLength;
     this.dataType = 'integer';
+    this.unsigned = unsigned;
+    this.zerofill = zerofill;
   }
 
   get UNSIGNED() {
@@ -168,8 +170,8 @@ class INTEGER extends DataType {
  * @param {number} dataLength
  */
 class TINYINT extends INTEGER {
-  constructor(dataLength?: number) {
-    super(dataLength);
+  constructor(dataLength?: number, unsigned?: boolean, zerofill?: boolean) {
+    super(dataLength, unsigned, zerofill);
     this.dataType = 'tinyint';
   }
 }
@@ -183,8 +185,8 @@ class TINYINT extends INTEGER {
  * @param {number} dataLength
  */
 class SMALLINT extends INTEGER {
-  constructor(dataLength?: number) {
-    super(dataLength);
+  constructor(dataLength?: number, unsigned?: boolean, zerofill?: boolean) {
+    super(dataLength, unsigned, zerofill);
     this.dataType = 'smallint';
   }
 }
@@ -198,8 +200,8 @@ class SMALLINT extends INTEGER {
  * @param {number} dataLength
  */
 class MEDIUMINT extends INTEGER {
-  constructor(dataLength?: number) {
-    super(dataLength);
+  constructor(dataLength?: number, unsigned?: boolean, zerofill?: boolean) {
+    super(dataLength, unsigned, zerofill);
     this.dataType = 'mediumint';
   }
 }
@@ -214,8 +216,8 @@ class MEDIUMINT extends INTEGER {
  * @param {number} dataLength
  */
 class BIGINT extends INTEGER {
-  constructor(dataLength?: number) {
-    super(dataLength);
+  constructor(dataLength?: number, unsigned?: boolean, zerofill?: boolean) {
+    super(dataLength, unsigned, zerofill);
     this.dataType = 'bigint';
   }
 }
@@ -482,7 +484,7 @@ const AllDataTypes = {
   VIRTUAL,
 };
 
-type DATA_TYPE<T> = AbstractDataType<T> & T;
+export type DATA_TYPE<T> = AbstractDataType<T> & T;
 
 class DataTypes {
   static STRING: DATA_TYPE<STRING> = STRING as any;

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,12 +1,12 @@
 import 'reflect-metadata';
 
 import Bone from './bone';
-import DataTypes, { DataType, AbstractDataType } from './data_types';
+import DataTypes, { DataType, DATA_TYPE } from './data_types';
 import { ASSOCIATE_METADATA_MAP } from './constants';
 import { ColumnBase, Validator, AssociateOptions } from './types/common';
 
 interface ColumnOption extends Omit<ColumnBase, 'columnName'| 'columnType'> {
-  type?: AbstractDataType<DataType>;
+  type?: DataType;
   name?: string;
   validate?: {
     [key: string]: Validator;
@@ -37,13 +37,13 @@ function findType(tsType) {
   }
 }
 
-export function Column(options?: ColumnOption | AbstractDataType<DataType>) {
+export function Column(options?: ColumnOption | DATA_TYPE<DataType>) {
   return function(target: Bone, propertyKey: string) {
     if (options == null) {
       options = {};
     }
     // target refers to model prototype, an internal instance of `Bone {}`
-    if (options['prototype'] instanceof DataType) options = { type: options as AbstractDataType<DataType> };
+    if (options['prototype'] instanceof DataType) options = { type: options as DATA_TYPE<DataType> };
 
     if (!('type' in options)) {
       const tsType = Reflect.getMetadata('design:type', target, propertyKey);

--- a/src/drivers/abstract/attribute.js
+++ b/src/drivers/abstract/attribute.js
@@ -73,10 +73,12 @@ function createType(DataTypes, params) {
     case 'MEDIUMINT':
     case 'INTEGER':
     case 'BIGINT':
+      return new DataType(type.dataLength, type.unsigned, type.zerofill);
     case 'BINARY':
     case 'VARBINARY':
     case 'CHAR':
     case 'VARCHAR':
+    case 'STRING':
       return new DataType(type.dataLength);
     default:
       return new DataType();

--- a/src/drivers/postgres/data_types.js
+++ b/src/drivers/postgres/data_types.js
@@ -41,8 +41,8 @@ class Postgres_BINARY extends DataTypes.BINARY {
 }
 
 class Postgres_INTEGER extends DataTypes.INTEGER {
-  constructor(dataLength) {
-    super(dataLength);
+  constructor(dataLength, unsigned, zerofill) {
+    super(dataLength, unsigned, zerofill);
   }
 
   uncast(value) {
@@ -55,8 +55,8 @@ class Postgres_INTEGER extends DataTypes.INTEGER {
 }
 
 class Postgres_BIGINT extends Postgres_INTEGER {
-  constructor() {
-    super();
+  constructor(dataLength, unsigned, zerofill) {
+    super(dataLength, unsigned, zerofill);
     this.dataType = 'bigint';
   }
 }

--- a/src/drivers/sqlite/data_types.js
+++ b/src/drivers/sqlite/data_types.js
@@ -34,8 +34,8 @@ class Sqlite_DATEONLY extends DataTypes.DATEONLY {
 }
 
 class Sqlite_INTEGER extends DataTypes.INTEGER {
-  constructor(dataLength) {
-    super(dataLength);
+  constructor(dataLength, unsigned, zerofill) {
+    super(dataLength, unsigned, zerofill);
   }
 
   uncast(value) {
@@ -44,8 +44,8 @@ class Sqlite_INTEGER extends DataTypes.INTEGER {
 
 }
 class Sqlite_BIGINT extends DataTypes.BIGINT {
-  constructor() {
-    super();
+  constructor(dataLength, unsigned, zerofill) {
+    super(dataLength, unsigned, zerofill);
     this.dataType = 'integer';
   }
 

--- a/test/types/decorators.test.ts
+++ b/test/types/decorators.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import { AttributeMeta, Bone, DataTypes, Column, HasMany, connect } from '../..';
 
-const { TEXT } = DataTypes;
+const { TEXT, STRING, INTEGER } = DataTypes;
 
 describe('=> Decorators (TypeScript)', function() {
   before(async function() {
@@ -201,6 +201,37 @@ describe('=> Decorators (TypeScript)', function() {
     });
 
     it('should work with other options', async () => {
+      class Note extends Bone {
+        @Column()
+        id: bigint;
+
+        @Column({
+          type: STRING
+        })
+        body: string;
+
+        @Column({
+          type: STRING(64)
+        })
+        description: string;
+
+        @Column({
+          type: INTEGER(2).UNSIGNED,
+        })
+        status: number;
+      }
+      await Note.sync({ force: true });
+      assert.deepEqual(Object.keys(Note.attributes), [ 'id', 'body', 'description', 'status' ]);
+
+      const { id, body, description, status } = Note.attributes;
+      assert.equal((id as AttributeMeta).toSqlString(), '`id` BIGINT PRIMARY KEY AUTO_INCREMENT');
+      assert.equal((body as AttributeMeta).toSqlString(), '`body` VARCHAR(255)');
+      assert.equal((description as AttributeMeta).toSqlString(), '`description` VARCHAR(64)');
+      assert.equal((status as AttributeMeta).toSqlString(), '`status` INTEGER(2) UNSIGNED');
+
+    });
+
+    it('should work with type options', async () => {
       class Note extends Bone {
         @Column({
           primaryKey: true,

--- a/test/unit/data_types.test.js
+++ b/test/unit/data_types.test.js
@@ -49,6 +49,8 @@ describe('=> Data Types', () => {
     assert.equal(new TINYINT(1).toSqlString(), 'TINYINT(1)');
     assert.equal(new TINYINT().UNSIGNED.toSqlString(), 'TINYINT UNSIGNED');
     assert.equal(new TINYINT().UNSIGNED.ZEROFILL.toSqlString(), 'TINYINT UNSIGNED ZEROFILL');
+    assert.equal(new TINYINT(1, true, true).toSqlString(), 'TINYINT(1) UNSIGNED ZEROFILL');
+
   });
 
   it('SMALLINT', () => {
@@ -56,6 +58,8 @@ describe('=> Data Types', () => {
     assert.equal(new SMALLINT(1).toSqlString(), 'SMALLINT(1)');
     assert.equal(new SMALLINT().UNSIGNED.toSqlString(), 'SMALLINT UNSIGNED');
     assert.equal(new SMALLINT().UNSIGNED.ZEROFILL.toSqlString(), 'SMALLINT UNSIGNED ZEROFILL');
+    assert.equal(new SMALLINT(1, true, true).toSqlString(), 'SMALLINT(1) UNSIGNED ZEROFILL');
+
   });
 
   it('MEDIUMINT', () => {
@@ -63,6 +67,7 @@ describe('=> Data Types', () => {
     assert.equal(new MEDIUMINT(1).toSqlString(), 'MEDIUMINT(1)');
     assert.equal(new MEDIUMINT().UNSIGNED.toSqlString(), 'MEDIUMINT UNSIGNED');
     assert.equal(new MEDIUMINT().UNSIGNED.ZEROFILL.toSqlString(), 'MEDIUMINT UNSIGNED ZEROFILL');
+    assert.equal(new MEDIUMINT(1, true, true).toSqlString(), 'MEDIUMINT(1) UNSIGNED ZEROFILL');
   });
 
   it('INTEGER', () => {
@@ -70,11 +75,13 @@ describe('=> Data Types', () => {
     assert.equal(new INTEGER(10).toSqlString(), 'INTEGER(10)');
     assert.equal(new INTEGER().UNSIGNED.toSqlString(), 'INTEGER UNSIGNED');
     assert.equal(new INTEGER().UNSIGNED.ZEROFILL.toSqlString(), 'INTEGER UNSIGNED ZEROFILL');
+    assert.equal(new INTEGER(1, true, true).toSqlString(), 'INTEGER(1) UNSIGNED ZEROFILL');
   });
 
   it('BIGINT', () => {
     assert.equal(new BIGINT().dataType, 'bigint');
     assert.equal(new BIGINT().UNSIGNED.toSqlString(), 'BIGINT UNSIGNED');
+    assert.equal(new BIGINT(1, true, true).toSqlString(), 'BIGINT(1) UNSIGNED ZEROFILL');
   });
 
   it('DECIMAL', () => {

--- a/test/unit/drivers/mysql/attribute.test.js
+++ b/test/unit/drivers/mysql/attribute.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert').strict;
 const Attribute = require('../../../../src/drivers/mysql/attribute');
-const { BOOLEAN, DATE, JSONB, STRING } = Attribute.DataTypes;
+const { BOOLEAN, DATE, JSONB, STRING, INTEGER } = Attribute.DataTypes;
 
 describe('=> Attribute (mysql)', function() {
   it('should support TINYINT(1)', async function() {
@@ -41,6 +41,18 @@ describe('=> Attribute (mysql)', function() {
       unique: true,
     });
     assert.equal(attribute.toSqlString(), '`isbn` VARCHAR(255) NOT NULL UNIQUE');
+  });
+
+  it('invokable type should work', async function() {
+    const attribute = new Attribute('isbn', {
+      type: new STRING(60),
+    });
+    assert.equal(attribute.toSqlString(), '`isbn` VARCHAR(60)');
+
+    const attribute1 = new Attribute('idd', {
+      type: new INTEGER(2).UNSIGNED,
+    });
+    assert.equal(attribute1.toSqlString(), '`idd` INTEGER(2) UNSIGNED');
   });
 
 });

--- a/test/unit/drivers/postgres/attribute.test.js
+++ b/test/unit/drivers/postgres/attribute.test.js
@@ -55,4 +55,16 @@ describe('=> Attribute (postgres)', function() {
     });
     assert.equal(attribute.toSqlString(), '"isbn" VARCHAR(255) NOT NULL UNIQUE');
   });
+
+  it('invokable type should work', async function() {
+    const attribute = new Attribute('isbn', {
+      type: new STRING(60),
+    });
+    assert.equal(attribute.toSqlString(), '"isbn" VARCHAR(60)');
+
+    const attribute1 = new Attribute('idd', {
+      type: new INTEGER(2).UNSIGNED,
+    });
+    assert.equal(attribute1.toSqlString(), '"idd" INTEGER(2) UNSIGNED');
+  });
 });

--- a/test/unit/drivers/sqlite/attribute.test.js
+++ b/test/unit/drivers/sqlite/attribute.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert').strict;
 const Attribute = require('../../../../src/drivers/sqlite/attribute');
-const { BIGINT, DATE, STRING } = Attribute.DataTypes;
+const { BIGINT, DATE, STRING, INTEGER } = Attribute.DataTypes;
 
 describe('=> Attribute (sqlite)', function() {
   it('should support DATETIME', async function() {
@@ -27,5 +27,17 @@ describe('=> Attribute (sqlite)', function() {
       unique: true,
     });
     assert.equal(attribute.toSqlString(), '"isbn" VARCHAR(255) NOT NULL UNIQUE');
+  });
+
+  it('invokable type should work', async function() {
+    const attribute = new Attribute('isbn', {
+      type: new STRING(60),
+    });
+    assert.equal(attribute.toSqlString(), '"isbn" VARCHAR(60)');
+
+    const attribute1 = new Attribute('idd', {
+      type: new INTEGER(2).UNSIGNED,
+    });
+    assert.equal(attribute1.toSqlString(), '"idd" INTEGER(2) UNSIGNED');
   });
 });

--- a/test/unit/hooks.test.js
+++ b/test/unit/hooks.test.js
@@ -55,7 +55,7 @@ describe('hooks', function() {
             obj.nickname = obj.realname + 'y';
           }
         },
-        afterCreate(obj){
+        afterCreate(obj) {
           obj.status = 10;
         },
         beforeBulkCreate() {
@@ -160,7 +160,7 @@ describe('hooks', function() {
       constructor(opts) {
         super(opts);
       }
-      
+
       getFingerprint() {
         return this.attribute('fingerprint');
       }
@@ -604,7 +604,7 @@ describe('hooks', function() {
             obj.email = 'hello@yo.com';
           }
         },
-        afterSave(obj){
+        afterSave(obj) {
           obj.status = 10;
         },
       }


### PR DESCRIPTION

* INTEGER like data type and STRING extra options didn't work in polymorphism
```js
// `idd` INTEGER(2) UNSIGNED
new Attribute('idd', { type: new INTEGER(2).UNSIGNED }).toSqlString();
//`isbn` VARCHAR(60)
new Attribute('isbn', { type: new STRING(60) }).toSqlString();
```
* fix decorators ColumnOptions.type to support invokable
```ts
@Column({
  type: STRING
})
body: string;

@Column({
  type: STRING(64)
})
description: string;

@Column({
  type: INTEGER(2).UNSIGNED,
})
status: number;
```