### PR TITLE
fix: AssociationOptions.select? should be supported

### DIFF
--- a/src/bone.js
+++ b/src/bone.js
@@ -224,6 +224,7 @@ class Bone {
     this.#raw = Object.assign({}, this.getRaw(), target.getRaw());
     this.#rawSaved = Object.assign({}, this.getRawSaved(), target.getRawSaved());
     this.#rawPrevious = Object.assign({}, this.getRawPrevious(), target.getRawPrevious());
+    this.#rawUnset = target._getRawUnset();
   }
 
   /**

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -68,6 +68,7 @@ export interface AssociateOptions {
   foreignKey?: string;
   through?: string;
   where?: Record<string, Literal>;
+  select?: string[] | ((name: string) => boolean);
 }
 
 export type command = 'select' | 'insert' | 'bulkInsert' | 'update' | 'delete' | 'upsert';


### PR DESCRIPTION
also fixed an issue about bone.clone(), which didn't overwrite the original unset attribute set correctly