### PR TITLE
fix: return type of realm.query, realm.transaction, and Bone.transation

### DIFF
--- a/src/bone.js
+++ b/src/bone.js
@@ -1067,9 +1067,7 @@ class Bone {
    * The primary key of the model, in camelCase.
    * @type {string}
    */
-  static get primaryKey() {
-    return 'id';
-  }
+  static primaryKey = 'id';
 
   /**
    * The primary column of the model, in snake_case, usually.
@@ -1255,7 +1253,7 @@ class Bone {
     }
     const { className } = opts;
     const Model = this.models[className];
-    if (!Model) throw new Error(`unable to find model "${className}"`);
+    if (!Model) throw new Error(`unable to find associated model "${className}" (model ${this.name})`);
     if (opts.foreignKey && Model.attributes[opts.foreignKey] && Model.attributes[opts.foreignKey].virtual) {
       throw new Error(`unable to use virtual attribute ${opts.foreignKey} as foreign key in model ${Model.name}`);
     }
@@ -1590,9 +1588,9 @@ class Bone {
         await this.driver.query('BEGIN', [], {  connection, Model: this, command: 'BEGIN' });
         while (true) {
           const { value: spell, done } = gen.next(result);
-          if (done) break;
           if (spell instanceof Spell) spell.connection = connection;
-          result = typeof spell.then === 'function' ? await spell : spell;
+          result = spell && typeof spell.then === 'function' ? await spell : spell;
+          if (done) break;
         }
         await this.driver.query('COMMIT', [], {  connection, Model: this, command: 'COMMIT' });
       } catch (err) {

--- a/src/realm.js
+++ b/src/realm.js
@@ -230,8 +230,8 @@ class Realm {
     }
 
     return {
+      ...restRes,
       rows: results.length > 0 ? results : rows,
-      ...restRes
     };
   }
 

--- a/src/types/abstract_bone.d.ts
+++ b/src/types/abstract_bone.d.ts
@@ -2,12 +2,11 @@ import DataTypes, { AbstractDataType, DataType } from "../data_types";
 import { 
   Pool, Literal, WhereConditions,
   Collection, ResultSet, InstanceValues, OrderOptions,
-  QueryOptions, AttributeMeta, AssociateOptions, Values, Connection, BulkCreateOptions,
+  QueryOptions, AttributeMeta, AssociateOptions, Values, Connection, BulkCreateOptions, 
+  GeneratorReturnType,
 } from './common';
 import { AbstractDriver } from '../drivers';
 import { Spell } from '../spell';
-
-export type RawQueryResult = typeof AbstractBone | ResultSet | boolean | number;
 
 interface SyncOptions {
   force?: boolean;
@@ -216,9 +215,9 @@ export class AbstractBone {
    *   yield Muscle.create({ boneId: bone.id, bar: 1 })
    * });
    */
-  static transaction(callback: GeneratorFunction): Promise<RawQueryResult>;
-  static transaction(callback: (connection: TransactionOptions) => Promise<RawQueryResult | void>): Promise<RawQueryResult>;
-
+  static transaction<T extends (connection: Connection) => Generator>(callback: T): Promise<GeneratorReturnType<ReturnType<T>>>;
+  static transaction<T extends (connection: Connection) => Promise<any>>(callback: T): Promise<ReturnType<T>>;
+  
   static describe(): Promise<{[key: string]: any[]}>;
 
   /**

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -178,3 +178,6 @@ export type InstanceValues<T> = {
 
 export type BeforeHooksType = 'beforeCreate' | 'beforeBulkCreate' | 'beforeUpdate' | 'beforeSave' |  'beforeUpsert' | 'beforeRemove';
 export type AfterHooksType = 'afterCreate' | 'afterBulkCreate' | 'afterUpdate' | 'afterSave' | 'afterUpsert' | 'afterRemove';
+
+// https://stackoverflow.com/a/67232225/179691
+type GeneratorReturnType<T extends Generator> = T extends Generator<any, infer R, any> ? R: never;

--- a/test/integration/suite/querying.test.js
+++ b/test/integration/suite/querying.test.js
@@ -706,7 +706,7 @@ describe('=> Transaction', function() {
   it('Bone.transaction()', async function() {
     const result = await Post.transaction(function* () {
       yield new Post({ title: 'Leah' }).create();
-      yield new Post({ title: 'Diablo' }).create();
+      return new Post({ title: 'Diablo' }).create();
     });
 
     const posts = await Post.find();

--- a/test/models/book.js
+++ b/test/models/book.js
@@ -3,9 +3,10 @@
 const { Bone } = require('../..');
 
 class Book extends Bone {
-  static get primaryKey() {
-    return 'isbn';
-  }
+  // static get primaryKey() {
+  //   return 'isbn';
+  // }
+  static primaryKey = 'isbn';
 
   set isbn(value) {
     if (!value) throw new Error('invalid isbn');

--- a/test/types/basics.test.ts
+++ b/test/types/basics.test.ts
@@ -1,8 +1,10 @@
 import { strict as assert } from 'assert';
-import { Bone, Column, DataTypes, connect } from '../..';
+import Realm, { Bone, Column, DataTypes, connect } from '../..';
 
 describe('=> Basics (TypeScript)', function() {
   const { TEXT } = DataTypes;
+  let realm: Realm;
+
   class Post extends Bone {
     static table = 'articles';
 
@@ -52,7 +54,7 @@ describe('=> Basics (TypeScript)', function() {
   }
 
   before(async function() {
-    await connect({
+    realm = await connect({
       dialect: 'sqlite',
       database: '/tmp/leoric.sqlite3',
       models: [ Post ],
@@ -297,6 +299,25 @@ describe('=> Basics (TypeScript)', function() {
       assert.equal(posts[0].title, 'Leah');
       assert.equal(posts[1].title, 'Cain');
       assert.equal(posts[2].title, 'Nephalem');
+    });
+  });
+
+  describe('=> Transaction', function() {
+    it('realm.transaction(function* () {})', async function() {
+      const result = await realm.transaction(function* () {
+        yield true;
+        return 1;
+      });
+      // tsc should be able to infer that the type of result is number
+      assert.equal(result, 1);
+    });
+
+    it('realm.transaction(async function() {})', async function() {
+      const result = await realm.transaction(async function() {
+        return 1;
+      });
+      // tsc should be able to infer that the type of result is number
+      assert.equal(result, 1);
     });
   });
 });


### PR DESCRIPTION
also loosened up the default Bone.primaryKey a bit to allow subclass to override with `static primaryKey = ` etc.