### PR TITLE
fix: date strings should be parsed with system time zone considered

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,13 +49,13 @@
     "node": ">= 12.0.0"
   },
   "dependencies": {
+    "dayjs": "^1.10.3",
     "debug": "^3.1.0",
     "deep-equal": "^2.0.5",
     "heredoc": "^1.3.1",
     "pluralize": "^7.0.0",
     "reflect-metadata": "^0.1.13",
     "sqlstring": "^2.3.0",
-    "strftime": "^0.10.0",
     "validator": "^13.5.2"
   },
   "devDependencies": {
@@ -65,7 +65,6 @@
     "@journeyapps/sqlcipher": "^5.2.0",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.10.1",
-    "dayjs": "^1.10.3",
     "eslint": "^7.20.0",
     "eslint-plugin-no-only-tests": "^3.0.0",
     "expect.js": "^0.3.1",

--- a/src/data_types.ts
+++ b/src/data_types.ts
@@ -1,5 +1,6 @@
 import Raw from './raw';
 import util from 'util';
+import dayjs from 'dayjs';
 const invokableFunc = require('./utils/invokable');
 
 export enum LENGTH_VARIANTS {
@@ -316,14 +317,13 @@ class DATE extends DataType {
     // @deprecated
     // vaguely standard date formats such as 2021-10-15 15:50:02,548
     if (typeof value === 'string' && rDateFormat.test(value)) {
-      // 2021-10-15 15:50:02,548 => 2021-10-15T15:50:02,548,
-      // 2021-10-15 15:50:02 => 2021-10-15T15:50:02.000
-      value = new Date(`${value.replace(' ', 'T').replace(',', '.')}`);
+      // 2021-10-15 15:50:02,548 => 2021-10-15 15:50:02.548,
+      value = dayjs(`${value.replace(',', '.')}`).toDate();
     }
 
     // 1634611135776
     // '2021-10-15T08:38:43.877Z'
-    if (!(value instanceof Date)) value = new Date((value as string));
+    if (!(value instanceof Date)) value = dayjs((value as string)).toDate();
     if (isNaN((value as any))) throw new Error(util.format('invalid date: %s', originValue));
 
     return this._round(value);

--- a/src/drivers/mysql/spellbook.js
+++ b/src/drivers/mysql/spellbook.js
@@ -39,7 +39,7 @@ class MySQLSpellBook extends Spellbook {
     const { columnAttributes, primaryColumn } = Model;
 
     if (Array.isArray(updateOnDuplicate) && updateOnDuplicate.length) {
-      columns = updateOnDuplicate.map(column => (columnAttributes[column] && columnAttributes[column].columnName ) || column)
+      columns = updateOnDuplicate.map(column => (columnAttributes[column] && columnAttributes[column].columnName) || column)
         .filter(column => column !== primaryColumn);
     } else if (!columns.length) {
       columns = Object.values(columnAttributes).map(attribute => attribute.columnName).filter(column => column !== primaryColumn);
@@ -80,7 +80,7 @@ class MySQLSpellBook extends Spellbook {
 
   /**
    * DELETE ... ORDER BY ...LIMIT
-   * @param {Spell} spell 
+   * @param {Spell} spell
    */
   formatDelete(spell) {
     const result = super.formatDelete(spell);

--- a/src/drivers/sqlite/index.js
+++ b/src/drivers/sqlite/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const strftime = require('strftime');
+const dayjs = require('dayjs');
 const { performance } = require('perf_hooks');
 
 const AbstractDriver = require('../abstract');
@@ -46,7 +46,7 @@ class SqliteDriver extends AbstractDriver {
     if (values) {
       values = values.map(entry => {
         if (entry instanceof Date) {
-          return strftime('%Y-%m-%d %H:%M:%S.%L %:z', entry);
+          return dayjs(entry).format('YYYY-MM-DD HH:mm:ss.SSS Z');
         }
         return entry;
       });

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const dayjs = require('dayjs');
 const fs = require('fs').promises;
 const path = require('path');
-const strftime = require('strftime');
 
 async function loadTasks(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
@@ -61,7 +61,7 @@ async function rollback(step = 1) {
 
 async function createMigrationFile(name) {
   const { migrations: dir } = this.options;
-  const timestamp = strftime('%Y%m%d%H%M%S');
+  const timestamp = dayjs().format('YYYYMMDDHHmmss');
   const fpath = path.join(dir, `${timestamp}-${name}.js`);
   await fs.writeFile(fpath, `'use strict';
 

--- a/test/integration/custom.test.js
+++ b/test/integration/custom.test.js
@@ -58,8 +58,8 @@ class MySpellbook extends SqliteDriver.Spellbook {
       obj[escapeId(Model.unalias(key))] = spell.sets[key];
       return obj;
     }, values);
-  
-    let whereArgs = [];
+
+    const whereArgs = [];
     let whereClause = '';
     if (whereConditions.length > 0) {
       for (const condition of whereConditions) collectLiteral(spell, condition, whereArgs);
@@ -77,7 +77,7 @@ class MySpellbook extends SqliteDriver.Spellbook {
     const { Model, whereConditions } = spell;
     const { escapeId } = Model.driver;
     const table = escapeId(spell.table.value);
-    let whereArgs = [];
+    const whereArgs = [];
     let whereClause = '';
     if (whereConditions.length > 0) {
       for (const condition of whereConditions) collectLiteral(spell, condition, whereArgs);
@@ -94,7 +94,7 @@ class MySpellbook extends SqliteDriver.Spellbook {
     const { Model, sets } = spell;
     const { escapeId } = Model.driver;
     const table = escapeId(spell.table.value);
-    let values = {};
+    const values = {};
 
     const { shardingKey } = Model;
     if (shardingKey && sets[shardingKey] == null) {

--- a/test/integration/mysql.test.js
+++ b/test/integration/mysql.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert').strict;
 const path = require('path');
-const strftime = require('strftime');
+const dayjs = require('dayjs');
 
 const { connect } = require('../..');
 
@@ -91,7 +91,7 @@ describe('=> Data types (mysql)', function() {
       birthday: new Date(2021, 5, 26),
       sex: 'M',
     });
-    assert.equal(strftime('%Y-%m-%d', user.birthday), '2021-06-26');
+    assert.equal(dayjs(user.birthday).format('YYYY-MM-DD'), '2021-06-26');
   });
 
   it('CHAR', async function() {

--- a/test/integration/suite/data_types.test.js
+++ b/test/integration/suite/data_types.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert').strict;
-const strftime = require('strftime');
+const dayjs = require('dayjs');
 
 const { Bone, DataTypes } = require('../../..');
 const { INTEGER, STRING, DATE, DATEONLY, TEXT, BOOLEAN, JSON, JSONB, BIGINT } = DataTypes;
@@ -270,7 +270,7 @@ describe('=> Data types - DATE', function() {
     });
 
     await assert.doesNotReject(async function() {
-      const result = await Note.where({ createdAt: strftime('%Y-%m-%d %H:%M:%S,%L', date) });
+      const result = await Note.where({ createdAt: dayjs(date).format('YYYY-MM-DD HH:mm:ss,SSS') });
       assert.equal(result.length, 1);
     });
 
@@ -319,7 +319,7 @@ describe('=> Data types - DATEONLY', function() {
     const date = new Date('2021-10-15T08:38:43.877Z');
     const note = await Note.create({ createdAt: date });
     await note.reload();
-    assert.equal(strftime('%Y-%m-%d', note.createdAt), '2021-10-15');
+    assert.equal(dayjs(note.createdAt).format('YYYY-MM-DD'), '2021-10-15');
 
     await assert.doesNotReject(async function() {
       const result = await Note.where({ createdAt: date });

--- a/test/integration/suite/migrations.test.js
+++ b/test/integration/suite/migrations.test.js
@@ -3,7 +3,7 @@
 const assert = require('assert').strict;
 const fs = require('fs').promises;
 const path = require('path');
-const strftime = require('strftime');
+const dayjs = require('dayjs');
 
 const Realm = require('../../..');
 const Logger = require('../../../src/drivers/abstract/logger');
@@ -15,7 +15,7 @@ const migrations = path.join(__dirname, '../migrations');
 // class Topic extends Realm.Bone {}
 
 async function createTopics() {
-  const name = `${strftime('%Y%m%d%H%M%S')}-create-topics.js`;
+  const name = `${dayjs().format('YYYYMMDDHHmmss')}-create-topics.js`;
   const fpath = path.join(migrations, name);
   await fs.writeFile(fpath, `'use strict';
 

--- a/test/unit/drivers/sqlite/index.test.js
+++ b/test/unit/drivers/sqlite/index.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert').strict;
 const path = require('path');
-const strftime = require('strftime');
+const dayjs = require('dayjs');
 
 const { heresql } = require('../../../../src/utils/string');
 const SqliteDriver = require('../../../../src/drivers/sqlite');
@@ -169,7 +169,7 @@ describe('=> SQLite driver.query()', () => {
     } = await driver.query(heresql(`
       SELECT datetime(created_at, 'localtime') AS created_at FROM notes
     `));
-    assert.equal(created_at, strftime('%Y-%m-%d %H:%M:%S', createdAt));
+    assert.equal(created_at, dayjs(createdAt).format('YYYY-MM-DD HH:mm:ss'));
   });
 
   it('should handle boolean correctly', async () => {

--- a/test/unit/expr_formatter.test.js
+++ b/test/unit/expr_formatter.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert').strict;
-const strftime = require('strftime');
+const dayjs = require('dayjs');
 const { connect, Bone } = require('../..');
 
 describe('=> formatExpr', function() {
@@ -35,7 +35,7 @@ describe('=> formatExpr', function() {
   it('should cast date with precision set in database', async function() {
     // users.birthday stores DATE without specific hours or so
     const today = new Date();
-    const formatted = strftime('%Y-%m-%d', today);
+    const formatted = dayjs(today).format('YYYY-MM-DD');
     assert.equal(
       User.where({ birthday: today }).toSqlString(),
       "SELECT * FROM `users` WHERE `birthday` = '" + formatted + " 00:00:00.000'"

--- a/test/unit/spell.test.js
+++ b/test/unit/spell.test.js
@@ -469,6 +469,13 @@ describe('=> Spell', function() {
     );
   });
 
+  it('where date', function() {
+    assert.equal(
+      Post.where('createdAt > ?', '2022-11-03').toString(),
+      "SELECT * FROM `articles` WHERE `gmt_create` > '2022-11-03 00:00:00.000' AND `gmt_deleted` IS NULL"
+    );
+  });
+
   it('where compound string conditions', function() {
     assert.equal(
       Post.where('title like "Arch%" or (title = "New Post" || title = "Skeleton King")').toString(),
@@ -623,8 +630,8 @@ describe('=> Spell', function() {
 
   it('order by string with multiple condition', () => {
     assert.equal(
-      Post.order('id asc, gmt_created desc').toString(),
-      'SELECT * FROM `articles` WHERE `gmt_deleted` IS NULL ORDER BY `id`, `gmt_created` DESC'
+      Post.order('id asc, gmt_create desc').toString(),
+      'SELECT * FROM `articles` WHERE `gmt_deleted` IS NULL ORDER BY `id`, `gmt_create` DESC'
     );
   });
 


### PR DESCRIPTION
```js
Post.where('createdAt > ?', '2022-11-03')
```

should generate following SQL

```sql
-- correct
SELECT * FROM articles WHERE gmt_create > '2022-11-03 00:00:00.000'
```

rather than 

```sql
-- wrong
SELECT * FROM articles WHERE gmt_create > '2022-11-02 16:00:00.000'
```
