### PR TITLE
fix: join conditions containing fields of base model should be allowed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
+.nyc_output
+coverage
+dist
+logs
 node_modules
 tmp
-coverage
-.nyc_output
+
+*.log
 docs/Gemfile.lock
 package-lock.json
 .DS_Store
@@ -9,11 +13,8 @@ test/types/*.js
 test/types/*.map
 test/integration/suite/sharding.test.js*
 test/models/photo.js*
+src/browser.js*
 src/decorators.js*
 src/data_types.js*
+src/drivers/sqljs/*.js*
 src/raw.js*
-
-# Logs
-logs
-*.log
-dist/

--- a/test/dumpfile.sql
+++ b/test/dumpfile.sql
@@ -74,7 +74,8 @@ CREATE TABLE `likes` (
   `id` bigint(20) AUTO_INCREMENT PRIMARY KEY,
   `gmt_create` timestamp(3) NULL,
   `gmt_modified` timestamp DEFAULT CURRENT_TIMESTAMP,
-  `article_id` bigint(20) NOT NULL,
+  `target_id` bigint(20) NOT NULL,
+  `target_type` bigint(20) NOT NULL,
   `user_id` bigint(20) NOT NULL,
   `gmt_deleted` timestamp(3) NULL
 );

--- a/test/integration/suite/associations.test.js
+++ b/test/integration/suite/associations.test.js
@@ -6,6 +6,7 @@ const sinon = require('sinon');
 
 const Attachment = require('../../models/attachment');
 const Comment = require('../../models/comment');
+const Like = require('../../models/like');
 const Post = require('../../models/post');
 const Tag = require('../../models/tag');
 const TagMap = require('../../models/tagMap');
@@ -76,7 +77,8 @@ describe('=> Associations', function() {
       Attachment.remove({}, true),
       Comment.remove({}, true),
       TagMap.remove({}, true),
-      Tag.remove({}, true)
+      Tag.remove({}, true),
+      Like.remove({ userId: 1 }, true),
     ]);
   });
 
@@ -94,6 +96,14 @@ describe('=> Associations', function() {
   it('Bone.belongsTo', async function() {
     const attachment = await Attachment.first.with('post');
     expect(attachment.post).to.be.a(Post);
+  });
+
+  it('Bone.belongsTo({ where })', async function() {
+    await Like.create({ targetId: 1, targetType: 0, userId: 1 });
+    await assert.doesNotReject(async function() {
+      const like = await Like.findOne({ userId: 1 }).with('post');
+      assert.ok('post' in like);
+    });
   });
 
   it('Bone.hasMany', async function() {

--- a/test/integration/suite/querying.test.js
+++ b/test/integration/suite/querying.test.js
@@ -768,13 +768,13 @@ describe('=> Sharding', function() {
 
   it('should throw if sharding key is defined but not set when INSERT', async function() {
     await assert.rejects(async () => {
-      await new Like({ articleId: 1, userId: null }).create({ validate: false });
+      await new Like({ targetId: 1, targetType: 0, userId: null }).create({ validate: false });
     }, /sharding key/i);
   });
 
   it('should not throw if sharding key is defined and set when INSERT', async function() {
     await assert.doesNotReject(async () => {
-      await new Like({ userId: 1, articleId: 1 }).create();
+      await new Like({ userId: 1, targetId: 1, targetType: 0 }).create();
     }, /sharding key/i);
   });
 
@@ -803,7 +803,7 @@ describe('=> Sharding', function() {
   });
 
   it('should append sharding key to DELETE condition', async function() {
-    const like = await Like.create({ articleId: 1, userId: 1 });
+    const like = await Like.create({ targetId: 1, targetType: 0, userId: 1 });
     await assert.doesNotReject(async () => {
       await like.remove();
       await like.remove(true);
@@ -811,15 +811,15 @@ describe('=> Sharding', function() {
   });
 
   it('should append sharding key to UPDATE condition', async function() {
-    const like = await Like.create({ articleId: 1, userId: 1});
-    like.articleId = 2;
+    const like = await Like.create({ targetId: 1, targetType: 0, userId: 1});
+    like.targetId = 2;
     await assert.doesNotReject(async () => {
       await like.update();
     }, /sharding key/i);
   });
 
   it('should append sharking key to SELECT condition', async function() {
-    const like = await Like.create({ articleId: 1, userId: 1});
+    const like = await Like.create({ targetId: 1, targetType: 0, userId: 1});
     await assert.doesNotReject(async () => {
       await like.reload();
     }, /sharding key/);

--- a/test/models/like.js
+++ b/test/models/like.js
@@ -2,6 +2,11 @@
 
 const { Bone } =require('../..');
 
+const TARGET_TYPE = {
+  post: 0,
+  comment: 1,
+};
+
 class Like extends Bone {
   static get table() {
     return 'likes';
@@ -13,6 +18,13 @@ class Like extends Bone {
 
   static get shardingKey() {
     return 'userId';
+  }
+
+  static initialize() {
+    this.belongsTo('post', {
+      foreignKey: 'targetId',
+      where: { 'likes.targetType': TARGET_TYPE.post },
+    });
   }
 }
 


### PR DESCRIPTION
TDDL has validates sharding key fuzzily that disallow queries like below if sharding key is applied:

```sql
select * from (select * from resources where author_id = 1 limit 10) left join users on resources.author_id = users.id;
```

[TDDL-4500][ERR_PARSER] You have an error in your SQL syntax; Error occurs around this fragment: (...abbreviated)

this pr also fixes an issue regarding additional join conditions with `@BelongsTo({ where })` if `where` contains fields on base model, such as:

```ts
class Like extends Bone {
  @BelongsTo({ foreignKey: 'targetId', where: { 'likes.targetType': 'Post' })
  post: Post;
}
```

