### PR TITLE
fix: typo DataType for AbstractDriver

### DIFF
--- a/src/drivers/index.d.ts
+++ b/src/drivers/index.d.ts
@@ -20,7 +20,7 @@ export interface ConnectOptions {
 export class AbstractDriver {
 
   static Spellbook: typeof Spellbook;
-  static DataType: typeof DataType;
+  static DataTypes: typeof DataType;
   static Attribute: typeof Attribute;
 
   /**


### PR DESCRIPTION
![image](https://github.com/cyjake/leoric/assets/6828924/002974f1-bedd-45a2-a034-ff7ebe434765)

![image](https://github.com/cyjake/leoric/assets/6828924/7440378f-324d-4eb8-9a94-943f97ac1273)
