### PR TITLE
chore: inferred type might still require by subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,15 @@
   "browser": "dist/browser.js",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "exports": "./lib/index.js",
+  "exports": {
+    ".": {
+      "default": "./lib/index.js",
+      "types": "./lib/index.d.ts"
+    },
+    "./lib/*.d.ts": {
+      "default": "./lib/*.d.ts"
+    }
+  },
   "files": [
     "dist",
     "lib"


### PR DESCRIPTION
```ts
[TS Error] The inferred type of 'index' cannot be named without a reference to '../../../../node_modules/leoric/lib/types/common'. This is likely not portable. A type annotation is necessary. (src/controller/api/dashboard/template.ts:136:8)
```

intermediate inferred type might still use subpath to reference types such as `Collection`, `WhereConditions` etc. It seems this behavior cannot be customized via tsconfig, let's expose these files for now.