### PR TITLE
fix: type error in validate when using min max

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/src/drivers/sqljs/sqljs-connection.ts
+++ b/src/drivers/sqljs/sqljs-connection.ts
@@ -60,6 +60,7 @@ function nest(rows: Record<string, Literal>[], fields: string[], spell: SpellMet
 }
 
 async function defaultInitSqlJs(options: SqljsConnectionOptions): Promise<Database> {
+  // sql.js don't compatible with nodejs 14
   const { default: initSqlJs } = await import('sql.js');
   const SQL = await initSqlJs();
 

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -6,7 +6,7 @@ import { AbstractBone } from './abstract_bone';
 export type Literal = null | undefined | boolean | number | bigint | string | Date | Record<string, any> | ArrayBuffer;
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-type BaseValidateArgs = boolean | RegExp | Function | Array<Array<Literal>> | string | Array<Literal>;
+type BaseValidateArgs = boolean | RegExp | Function | Array<Array<Literal>> | string | Array<Literal> | number;
 
 export type Validator = BaseValidateArgs | {
   args?: BaseValidateArgs,

--- a/test/types/decorators.test.ts
+++ b/test/types/decorators.test.ts
@@ -189,6 +189,15 @@ describe('=> Decorators (TypeScript)', function() {
           },
         })
         status!: number;
+
+        @Column({
+          type: DataTypes.INTEGER,
+          validate: {
+            min: 0,
+            max: 10,
+          },
+        })
+        count!: number;
       }
       await Note.sync({ force: true });
       let note = new Note({ name: '' });
@@ -204,6 +213,11 @@ describe('=> Decorators (TypeScript)', function() {
       await assert.rejects(async () => {
         await note.save();
       }, /Error status/);
+
+      note = new Note({ name: 'Github', count: 11 });
+      await assert.rejects(async () => {
+        await note.save();
+      }, /Validation max on count failed/);
     });
 
     it('should work with other options', async () => {


### PR DESCRIPTION
### Background
When using the built-in validators min and max like this
````ts
@Column({
  type: DataTypes.TINYINT,
  validate: {
    min: 0,
    max: 10,
  },
})
count: number;
````
It will trigger a TypeScript type error: `Type 'number' is not assignable to type 'Validator'`.

### Summary
Complete the type BaseValidateArgs