### PR TITLE
feat: support JSON_VALUE(j, '$.a' RETURNING CHAR(50))

### DIFF
--- a/test/unit/expr.test.js
+++ b/test/unit/expr.test.js
@@ -462,10 +462,33 @@ describe('=> parse arithmetic operators', function() {
   });
 });
 
-describe('parse malformed expression', function() {
+describe('=> parse malformed expression', function() {
   it('parse )', function() {
     assert.throws(function() {
       parseExpr(')');
-    });
-  }, /unexpected token/i);
+    }, /unexpected token/i);
+  });
+});
+
+describe('=> parse func with modifiers', function() {
+  it('parse JSON_VALUE()', function() {
+    assertExpr(
+      "JSON_VALUE(extra, '$.foo.bar' RETURNING CHAR(32))",
+      {
+        type: 'func',
+        name: 'json_value',
+        dataType: { length: '32', type: 'dataType', value: 'char' },
+        args: [
+          { type: 'id', value: 'extra' },
+          { type: 'literal', value: '$.foo.bar' },
+        ],
+      }
+    );
+  });
+
+  it('parse JSON_VALUE() with invalid RETURNING type', function() {
+    assert.throws(function() {
+      parseExpr("JSON_VALUE(j, '$.a' RETURNING VARCHAR(255))");
+    }, /unexpected returning type/i);
+  });
 });

--- a/test/unit/expr_formatter.test.js
+++ b/test/unit/expr_formatter.test.js
@@ -48,4 +48,18 @@ describe('=> formatExpr', function() {
       "SELECT * FROM `articles` WHERE `settings` LIKE '%foo%' AND `gmt_deleted` IS NULL"
     );
   });
+
+  it("should be able to process JSON_VALUE(j, '$.a' RETURNING CHAR(32))", async function() {
+    assert.equal(
+      Post.where({ "JSON_VALUE(extra, '$.a' RETURNING CHAR(32))": 'hello' }).toSqlString(),
+      "SELECT * FROM `articles` WHERE JSON_VALUE(`extra`, '$.a' RETURNING CHAR(32)) = 'hello' AND `gmt_deleted` IS NULL"
+    );
+  });
+
+  it("should be able to process JSON_VALUE(j, '$.b' RETURNING DECIMAL)", async function() {
+    assert.equal(
+      Post.where({ "JSON_VALUE(extra, '$.b' RETURNING DECIMAL)": 10 }).toSqlString(),
+      "SELECT * FROM `articles` WHERE JSON_VALUE(`extra`, '$.b' RETURNING DECIMAL) = 10 AND `gmt_deleted` IS NULL"
+    );
+  });
 });


### PR DESCRIPTION
It looks like the performance of querying properties in native JSON data type in MySQL can be boosted with specific index, as long as the index is created with JSON_VALUE(field, path RETURNING type) that casts the property value to certain type.

To enable this optimization, the expression parser and formatter in Leoric needs to be updated, hence proposed this pr.

- https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-21.html#mysqld-8-0-21-json
- https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#function_json-value
