### PR TITLE
fix: meta attributes should still be available if subclass-ed

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 22
 
       - name: npm install, build, and test
         run: |

--- a/test/unit/raw.test.js
+++ b/test/unit/raw.test.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { Raw } = require('../../src');
+const assert = require('assert').strict;
+
+describe('=> Raw', () => {
+  describe('constructor()', () => {
+    it('should throw if not called with string', async () => {
+      assert.throws(() => new Raw({ toSqlString() { return 'foo'; } }));
+    });
+  });
+});

--- a/test/unit/realm.test.js
+++ b/test/unit/realm.test.js
@@ -181,6 +181,30 @@ describe('=> Realm', () => {
     });
   });
 
+  describe('realm.connect', async () => {
+    class Post extends Bone {
+      static table = 'articles';
+    }
+
+    afterEach(async () => {
+      await Post.truncate();
+    });
+
+    it('realm.connect should set necessary static attributes on models', async () => {
+      const realm = new Realm({
+        port: process.env.MYSQL_PORT,
+        user: 'root',
+        database: 'leoric',
+        models: [ Post ],
+        subclass: true,
+      });
+      await realm.connect();
+      assert.ok(Post.driver);
+      assert.ok(Post.models);
+      assert.ok(Post.options);
+    });
+  });
+
   describe('realm.query', async () => {
 
     class Post extends Bone {


### PR DESCRIPTION
leoric models depends on several static attributes of parent class (namely `Bone`), such as driver, options, and models. For single data source scenarios, this won't be a problem. But if multiple data sources where introduced, like the midway leoric component, or the egg orm plugin, this could be problematic. 

```js
class Post extends Bone {}
```

Post model extends from the base class, but the actual base class in the realm will be changed to a subclass of Bone, Hence make Post unable to reference the meta attributes correctly. 