### PR TITLE
fix: object results should have attribute values casted as well

### DIFF
--- a/src/bone.js
+++ b/src/bone.js
@@ -1194,7 +1194,11 @@ class Bone {
     for (const key in data) {
       const value = data[key];
       const attribute = attributeMap[key];
-      result[attribute ? attribute.name : key] = value;
+      if (attribute) {
+        result[attribute.name] = attribute.cast(value);
+      } else {
+        result[key] = value;
+      }
     }
     return result;
   }


### PR DESCRIPTION
```typescript
class Post {
  @Column(DataTypes.JSONB)
  extra: Record<string, unknown>
}

const [post] = await Post.select('extra', "JSON_EXTRACT(extra, '$.foo') AS foo");
console.log(typeof post.extra); // expected "object", actually got "string"