### PR TITLE
fix(deps): bump esbuild to ^0.28.1 for path traversal fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@types/sqlstring": "^2.3.2",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
-    "esbuild": "^0.27.4",
+    "esbuild": "^0.28.1",
     "eslint": "^8.52.0",
     "eslint-plugin-no-only-tests": "^3.0.0",
     "expect.js": "^0.3.1",


### PR DESCRIPTION
## Summary
- Bumps `esbuild` from `^0.27.4` to `^0.28.1` to resolve [Dependabot alert #6](https://github.com/cyjake/leoric/security/dependabot/6)
- The vulnerability is a path traversal in esbuild's dev server on Windows (severity: low, affects `>= 0.27.3, < 0.28.1`)
- Dev dependency only — no impact on library consumers

## Test plan
- [x] Verified `docs/build-playground.mjs` builds successfully with esbuild 0.28.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)