### PR TITLE
release: v2.15.0-beta.2

### DIFF
--- a/History.md
+++ b/History.md
@@ -12,7 +12,12 @@
 * fix(types): enhance TypeScript definitions and improve type safety in… by @JimmyDaddy in https://github.com/cyjake/leoric/pull/464
 * Benchmark Proxy class field handling by @cyjake in https://github.com/cyjake/leoric/pull/466
 * Replace instance Proxy with model compilation by @cyjake in https://github.com/cyjake/leoric/pull/467
+* fix(deps): bump esbuild to ^0.28.1 for path traversal fix by @yicai-dev in https://github.com/cyjake/leoric/pull/469
+* fix: lazily load database clients via dynamic import() by @elrrrrrrr in https://github.com/cyjake/leoric/pull/465
+* fix: allow transparent runtime subclasses of compiled models by @yicai-dev in https://github.com/cyjake/leoric/pull/471
 
+## New Contributors
+* @elrrrrrrr made their first contribution in https://github.com/cyjake/leoric/pull/465
 
 **Full Changelog**: https://github.com/cyjake/leoric/compare/v2.14.0...v2.15.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leoric",
-  "version": "2.15.0-beta.1",
+  "version": "2.15.0-beta.2",
   "description": "yet another JavaScript object-relational mapping library",
   "browser": "dist/browser.js",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary

- Bump version to 2.15.0-beta.2
- Update History.md with changes since beta.1

## Changes since v2.15.0-beta.1

- fix: lazily load database clients via dynamic import() (#465)
- fix(deps): bump esbuild to ^0.28.1 for path traversal fix (#469)
- fix: allow transparent runtime subclasses of compiled models (#471)