### PR TITLE
fix: forward consumer opts from Realm.query() to driver.query()

### DIFF
--- a/src/raw.ts
+++ b/src/raw.ts
@@ -88,6 +88,7 @@ export async function rawQuery(
   });
 
   const { rows, ...restRes } = await driver.query(sql, values, {
+    ...opts,
     connection: opts.connection,
     Model: opts.model,
   } as any);

--- a/test/unit/raw.test.js
+++ b/test/unit/raw.test.js
@@ -83,6 +83,27 @@ describe('=> rawQuery()', () => {
     assert.equal(result.rows[0].result, 7);
   });
 
+  it('should pass through custom opts fields to driver.query()', async () => {
+    const originalQuery = realm.driver.query;
+    let receivedOpts;
+    realm.driver.query = function (sql, values, opts) {
+      receivedOpts = opts;
+      return originalQuery.call(this, sql, values, opts);
+    };
+    try {
+      const result = await realm.query('SELECT 8 AS result', [], {
+        logger: { label: 'custom-logger' },
+        traceId: 'trace-123',
+      });
+      assert.equal(result.rows[0].result, 8);
+      assert.ok(receivedOpts);
+      assert.deepEqual(receivedOpts.logger, { label: 'custom-logger' });
+      assert.equal(receivedOpts.traceId, 'trace-123');
+    } finally {
+      realm.driver.query = originalQuery;
+    }
+  });
+
   after(async () => {
     await realm.disconnect();
   });


### PR DESCRIPTION
## Summary

Fixes #474.

`rawQuery()` (introduced in bc1387f / #445) built a brand-new opts object for `driver.query()` containing only `connection` and `Model`, silently dropping any other consumer-provided opts fields (used for logging/tracing/context propagation/SQL scanning hooks, etc).

## Fix

Spread the original `opts` into the object passed to `driver.query()`, keeping `connection`/`Model` as explicit overrides so they still take priority:

```diff
 const { rows, ...restRes } = await driver.query(sql, values, {
+  ...opts,
   connection: opts.connection,
   Model: opts.model,
 } as any);
```

## Test

Added a regression test in `test/unit/raw.test.js` that hooks `driver.query()` and verifies custom opts fields (e.g. `logger`, `traceId`) passed via `realm.query(sql, values, opts)` reach the driver.

## Verification

- `npx mocha --node-option require=ts-node/register,enable-source-maps,loader=ts-node/esm test/unit/raw.test.js` — 10/10 passing
- `npx tsc --noEmit` — clean