### PR TITLE
fix: export markModelClassReady from index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import Realm from './realm';
 import { default as Raw, raw } from './raw';
 import { isBone } from './utils';
 import { hookNames } from './setup_hooks';
-import { LeoricClassFieldError, LeoricModelDefinitionError } from './abstract_bone';
+import { LeoricClassFieldError, LeoricModelDefinitionError, markModelClassReady } from './abstract_bone';
 import { LeoricModelCompilationError } from './model';
 
 import * as decorators from './decorators';
@@ -79,6 +79,7 @@ Object.assign(Realm, {
   LeoricModelDefinitionError,
   LeoricClassFieldError,
   LeoricModelCompilationError,
+  markModelClassReady,
   default: Realm,
 });
 
@@ -97,6 +98,7 @@ export {
   Raw,
   raw,
   isBone,
+  markModelClassReady,
   LeoricModelDefinitionError,
   LeoricClassFieldError,
   LeoricModelCompilationError,


### PR DESCRIPTION
## Summary

`markModelClassReady` is defined and exported from `abstract_bone.ts`, but was not re-exported from the package entry point (`src/index.ts`), so it was inaccessible via `require('leoric').markModelClassReady`.

Consumers that register `Bone` subclasses outside of `realm.connect()` / `realm.define()` (e.g. through a custom decorator) need `markModelClassReady` to satisfy the `MODEL_READY` check added to `AbstractBone`'s constructor, but the function was not part of the public API surface.

## Change

- Import `markModelClassReady` from `./abstract_bone` in `src/index.ts`.
- Add it to the `Object.assign(Realm, { ... })` block.
- Add it to the named `export { ... }` block.

## Verification

```
npx tsc
node -e "console.log(typeof require('./lib/index.js').markModelClassReady)"
# => function
```

Confirmed `lib/index.d.ts` also picks up the type via the existing named export list.

Fixes #473