### PR TITLE
fix: restore v2.14 type compatibility for hints and Bone.restore/update

### DIFF
--- a/src/bone.ts
+++ b/src/bone.ts
@@ -58,17 +58,17 @@ export default class Bone extends AbstractBone {
     return this._find().unscoped;
   }
 
-  static restore<T extends typeof Bone>(this: T, conditions: WhereConditions<T>, opts: QueryOptions = {}) {
-    return super._restore(conditions, opts);
+  static restore<T extends typeof Bone>(this: T, conditions: WhereConditions<T>, opts: QueryOptions = {}): Spell<T, number, false> {
+    return this._restore(conditions, opts) as Spell<T, number, false>;
   }
 
   static update<T extends typeof Bone, Key extends BoneColumns<T>>(
     this: T,
     conditions: WhereConditions<T>,
-    values: Partial<Record<Key, Literal | Raw>>,
+    values?: Partial<Record<Key, Literal | Raw>>,
     options: QueryOptions = {},
-  ) {
-    return super._update(conditions, values, options);
+  ): Spell<T, number, false> {
+    return this._update(conditions, values ?? {}, options) as Spell<T, number, false>;
   }
 
   /**

--- a/src/bone.ts
+++ b/src/bone.ts
@@ -68,7 +68,7 @@ export default class Bone extends AbstractBone {
     values?: Partial<Record<Key, Literal | Raw>>,
     options: QueryOptions = {},
   ): Spell<T, number, false> {
-    return this._update(conditions, values ?? {}, options) as Spell<T, number, false>;
+    return this._update(conditions, values as Partial<Record<Key, Literal | Raw>>, options) as Spell<T, number, false>;
   }
 
   /**

--- a/src/hint.ts
+++ b/src/hint.ts
@@ -33,6 +33,13 @@ export type HintScopeObject = {
   [key in INDEX_HINT_SCOPE_TYPE]?: string | string[];
 }
 
+export type CommonHintArgs = string | HintInterface | Hint | IndexHint | HintScopeObject;
+
+/**
+ * @deprecated use {@link CommonHintArgs} instead. Kept as an alias for backward compatibility with v2.14 typings.
+ */
+export type CommonHintsArgs = CommonHintArgs;
+
 export class Hint {
 
   #text = '';
@@ -96,7 +103,7 @@ export class IndexHint {
    * })
    */
   static build(
-    hint: string | IndexHint | HintInterface | HintScopeObject,
+    hint: string | string[] | IndexHint | HintInterface | HintScopeObject,
     type?: INDEX_HINT_TYPE,
     scope?: INDEX_HINT_SCOPE,
   ): IndexHint {
@@ -225,5 +232,3 @@ export class IndexHint {
     return result;
   }
 }
-
-export type CommonHintArgs = string | HintInterface | Hint | IndexHint | HintScopeObject;


### PR DESCRIPTION
## Why

The v2.15 TypeScript migration introduced a few unintentional breaking changes vs. the hand-written v2.14 `.d.ts` files. This restores compatibility so consumers upgrading from v2.14 don't hit new compile errors, and we can stay on a v2.15 minor/patch release instead of bumping to v3.

## What changed

**`src/hint.ts`**
- Re-added `CommonHintsArgs` as a deprecated alias of the renamed `CommonHintArgs` — the rename broke anyone importing the old (v2.14) name.
- `IndexHint.build()` now accepts `string[]` again for its `hint` param, matching both the v2.14 signature and the existing runtime `Array.isArray(hint)` check (which was previously untyped).

**`src/bone.ts`**
- `static restore` / `static update` now call `this._restore` / `this._update` instead of `super._restore` / `super._update`. Calling through `super` with a generic `this: T` method loses the polymorphic `this` inference in TS, which caused the returned `Spell`'s model type to collapse from `Spell<T, number>` to `Spell<typeof AbstractBone, number, false>`. Calling through `this` (with explicit return-type annotations) preserves the concrete subclass type, matching v2.14 behavior.
- `update()`'s `values` param is optional again (was `?` in v2.14).

## Verification

- `npx tsc --noEmit` — clean, no errors.
- `test/types/*.test.ts` (the dts test suite) compiles via ts-node with zero TypeScript errors. The only failures are pre-existing DB-connection issues in this sandbox (no MySQL/SQLite fixtures loaded), unrelated to these changes.

## Known remaining gaps (left as-is, non-breaking)

- `types/common.ts`'s `Pool` is now an `interface` instead of a `class` — theoretical break only if someone did `new Pool()` or extended it directly, which isn't a realistic usage pattern for a driver-internal type.
- The Sequelize adapter's generated `.d.ts` still shows some `/*elided*/ any` generic constraints, a `tsc` declaration-emit artifact from the mixin-factory pattern (`sequelize(Bone)` returning an anonymous class expression). This widens some generics to `any` rather than erroring, so it's a DX/precision regression, not a compile break. Could be a follow-up if we want tighter typings there.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>