### PR TITLE
fix(types): restore Pool class & sequelize adapter types; ci: bump Actions to node24

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -38,10 +38,10 @@ jobs:
         node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -63,7 +63,7 @@ jobs:
         MYSQL_ROOT_PASSWORD: password
 
     - name: Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -36,9 +36,9 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
 
@@ -62,8 +62,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
       run:
         working-directory: docs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -32,14 +32,14 @@ jobs:
           bundler-cache: true
           working-directory: docs
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
       - run: bundle exec jekyll build --baseurl ""
         env:
           JEKYLL_ENV: production
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_site
 
@@ -51,4 +51,4 @@ jobs:
     needs: build
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jsdoc": "rm -rf docs/api && jsdoc -c .jsdoc.json -d docs/api -t node_modules/@cara/minami",
     "clean": "tsc -b --clean",
     "lint-staged": "lint-staged",
-    "prepack": "tsc && npm run build:types:ts4.9",
+    "prepack": "tsc && node scripts/apply-dts-overrides.js && npm run build:types:ts4.9",
     "build:playground": "node docs/build-playground.mjs",
     "benchmark": "npm run benchmark:model-compilation",
     "benchmark:proxy": "tsc && node --expose-gc benchmarks/proxy-class-fields.js",

--- a/scripts/apply-dts-overrides.js
+++ b/scripts/apply-dts-overrides.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+'use strict';
+
+// tsc's declaration emitter widens some generics to `/*elided*/ any` when
+// declaring the anonymous class returned by the `sequelize()` mixin factory
+// (types/adapters/sequelize.ts). The hand-written declaration below models
+// the same public shape without hitting that emitter limitation, so it is
+// applied on top of the compiler's own output for the main (non-ts4.9)
+// declaration files as well.
+//
+// This runs before `build:types:ts4.9`, which copies from lib/ into
+// types/ts4.9/ and then applies its own overrides (see
+// scripts/build-ts49-types.js) — so the ts4.9 output picks up this fix too.
+
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+const libDir = path.join(rootDir, 'lib');
+const overridesDir = path.join(rootDir, 'types', 'ts4.9-overrides');
+
+const overrides = [
+  'adapters/sequelize.d.ts',
+];
+
+if (!fs.existsSync(libDir)) {
+  throw new Error(`missing ${libDir}; run "tsc" first`);
+}
+
+for (const relPath of overrides) {
+  const src = path.join(overridesDir, relPath);
+  const dest = path.join(libDir, relPath);
+  fs.copyFileSync(src, dest);
+  console.log(`applied override: ${relPath}`);
+}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -43,8 +43,8 @@ export interface Connection {
   release(): void;
 }
 
-export interface Pool {
-  getConnection(): Promise<Connection>;
+export abstract class Pool {
+  abstract getConnection(): Promise<Connection>;
 }
 
 export interface QueryOptions {

--- a/types/ts4.9-overrides/adapters/sequelize.d.ts
+++ b/types/ts4.9-overrides/adapters/sequelize.d.ts
@@ -1,6 +1,9 @@
 import { HookFunc } from '../setup_hooks';
 import Raw from '../raw';
-import { AbstractBone } from '../abstract_bone';
+import { AbstractBone, hasLoadedAttributesKey } from '../abstract_bone';
+// Re-export so consumers importing hasLoadedAttributesKey from the package root
+// (via `export * from './adapters/sequelize'` in index.ts) keep working.
+export { hasLoadedAttributesKey };
 import type Spell from '../spell';
 import type { Collection, Literal, QueryOptions } from '../types/common';
 


### PR DESCRIPTION
## Summary

Two independent fixes:

### 1. Type-declaration gaps left over from the v2.15 TS-native migration (follow-up to #477)

- `Pool` in `src/types/common.ts` was an `interface` in v2.15 but a `class` in v2.14. Restored it as an `abstract class` — TS classes are structurally typed unless they declare private members, so all existing object-literal/interface-like usages (`{} as Pool`, `pool: Pool`) keep compiling, while the nominal `class` shape (`extends Pool`, etc.) v2.14 consumers relied on is restored.
- The `sequelize()` mixin factory (`src/adapters/sequelize.ts`) returns an anonymous class expression, which makes `tsc`'s declaration emitter widen several generic constraints to `/*elided*/ any` in the generated `lib/adapters/sequelize.d.ts`. A hand-written override for exactly this problem already existed at `types/ts4.9-overrides/adapters/sequelize.d.ts`, but it was only ever applied to the legacy TS 4.9 declaration build. Added `scripts/apply-dts-overrides.js`, wired into `prepack` before `build:types:ts4.9`, so the primary `lib/` output benefits too. Also restored the `hasLoadedAttributesKey` re-export in the override so the package root's `export * from './adapters/sequelize'` isn't affected.

Verified via `npx tsc --noEmit`, a full `npm run prepack` rebuild (confirmed zero `/*elided*/ any` occurrences in both `lib/adapters/sequelize.d.ts` and `types/ts4.9/adapters/sequelize.d.ts`), and `npm run test:dts` — identical pass/fail counts before/after (26 passing / 27 failing, all failures pre-existing DB-connection issues from no MySQL/SQLite fixtures in this sandbox).

### 2. CI: bump GitHub Actions off the deprecated `node20` runtime

GitHub deprecated the `node20` runtime for JS-based Actions ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Actions still declaring `runs.using: node20` are now force-run on node24 with a deprecation warning, e.g.:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, codecov/codecov-action@v2.
```

Note this is unrelated to the `node-version` test matrix in `nodejs.yml` (still `[18.x, 20.x, 22.x, 24.x]`, testing leoric's own runtime compatibility) — it's about the runtime GitHub uses to execute the actions' own bundled JS.

Bumped affected actions to `node24`-declaring versions:
- `actions/checkout`: v4 → v7
- `actions/setup-node`: v4 → v7
- `codecov/codecov-action`: v2 → v5 (keeps the same `token` input; `fail_ci_if_error` still defaults to `false`, so a missing `CODECOV_TOKEN` secret won't fail the build)
- `actions/configure-pages`: v5 → v6
- `actions/upload-pages-artifact`: v3 → v5
- `actions/deploy-pages`: v4 → v5

`ruby/setup-ruby@v1` and `npmpublish.yml`'s `node-version: 24` were already fine.

## Verification

- `npx tsc --noEmit` — clean
- `npm run prepack` — clean rebuild, confirmed no `/*elided*/ any` in generated `.d.ts` files
- `npm run test:dts` — same 26 passing / 27 failing (DB-connection-only failures) as on `master`
- Confirmed no breaking config changes needed for the Actions version bumps (checked each action's release notes / `action.yml` inputs)