### PR TITLE
fix: use prerelease versioning strategy for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "release-type": "node",
       "package-name": "leoric",
       "changelog-path": "CHANGELOG.md",
+      "versioning": "prerelease",
       "prerelease": true,
       "prerelease-type": "beta"
     }


### PR DESCRIPTION
## Problem
PR #480 shows release-please proposing `2.15.1-beta.2` instead of the expected `2.15.0-beta.3`.

## Root cause
The `prerelease: true` config option only marks the **GitHub Release** itself as a prerelease — it does not control the version-bumping algorithm. Without an explicit `versioning` strategy, release-please used the default semver strategy (`fix:` commits → patch bump), producing `2.15.1` as the base version and then appending the stale `-beta.2` suffix, instead of using the dedicated prerelease-bump strategy that increments the beta counter.

## Fix
Add `"versioning": "prerelease"` to `release-please-config.json` so `fix`/`feat` commits increment the prerelease number (`-beta.N`) instead of bumping the base patch/minor version while on a beta line.

## Next steps
- Close/refresh PR #480 once this merges — release-please should recompute the Release PR to propose `2.15.0-beta.3`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>