### PR TITLE
fix: use GitHub-native changelog format and History.md for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
     ".": {
       "release-type": "node",
       "package-name": "leoric",
-      "changelog-path": "CHANGELOG.md",
+      "changelog-path": "History.md",
+      "changelog-type": "github",
       "versioning": "prerelease",
       "prerelease": true,
       "prerelease-type": "beta"


### PR DESCRIPTION
## Problem
1. `changelog-path` still defaulted to `CHANGELOG.md`, which would create a second, disconnected changelog file instead of appending to the existing `History.md`.
2. release-please's default changelog writer groups commits by conventional-commit type (`Features`, `Bug Fixes`, etc.), which is a different style than the "What's Changed" / "New Contributors" format History.md currently uses (generated via GitHub's release-notes API).

## Fix
- `"changelog-path": "History.md"` — append to the existing changelog file.
- `"changelog-type": "github"` — use the GitHub API's native release-notes generator, matching the format already present in `History.md`, instead of release-please's default conventional-commit grouping.

No changes to `npmpublish.yml`; still triggers on `release: published` regardless of changelog format.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>