### PR TITLE
ci: fix release-please tag format and upgrade action to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           target-branch: master

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "ac97840fb6f40cb340b2ec19c8672517b73972ed",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary
- Add `include-component-in-tag: false` to `release-please-config.json` so it looks for `v*` tags instead of `leoric-v*` (which don't exist), fixing the `Invalid previous_tag parameter` error
- Upgrade `googleapis/release-please-action` from v4 to v5 to resolve Node.js 20 deprecation warning

## Test plan
- [ ] Verify the action runs successfully on merge (triggers on push to master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)