### PR TITLE
fix: add types condition to exports for correct TypeScript resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./dist/index.js",
       "require": "./lib/index.js"
     }


### PR DESCRIPTION
## Summary

- Add `"types": "./lib/index.d.ts"` as the first condition in the `exports` field so TypeScript resolves the full type declarations instead of the simplified ESM build.

## Context

PR #485 added a conditional `exports` field (`import`/`require`) for the Node ESM entry, but omitted the `types` condition. When TypeScript resolves a package with `exports`, it prefers `exports` over the top-level `types` field. Without a `types` condition in `exports`, TS 5.x with `moduleResolution: node16`/`nodenext`/`bundler` falls back to resolving types from the ESM `dist/` build (which uses the simplified `SequelizeLikeBone` override from `types/ts4.9-overrides`) and drops:

- Generic signatures on `findAll` / `findOne` / `find` / `count` / `build` etc. (`<T extends typeof SequelizeBone>(this: T)` overloads are gone → `TS2558: Expected 0 type arguments`)
- Public method `Model.build()` (`TS2339: Property 'build' does not exist`)
- Type exports `SequelizeConditions` / `SequelizeInstanceUpdateOptions` (`TS2305: Module has no exported member`)

The full declarations in `lib/` still export all of these — the fix just makes TypeScript pick them up.

## Verification

Before this fix, with `leoric@2.15.0-beta.4`:

```bash
tsc --noEmit
# 73 errors: TS2339 (build), TS2305 (SequelizeConditions), TS2558 (findAll<T>)
```

After this fix:

```bash
tsc --noEmit
# 0 errors
```

Closes #487.

## Test plan

- [ ] `npm run build` still produces `lib/` and `dist/` correctly
- [ ] `npm test` passes
- [ ] Downstream consumer with TS 5.x + `moduleResolution: bundler` resolves `SequelizeConditions`, `Model.build()`, `findAll<T>()` correctly