### PR TITLE
chore: switch release-please from prerelease to stable channel

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,9 +8,7 @@
       "package-name": "leoric",
       "changelog-path": "History.md",
       "changelog-type": "github",
-      "versioning": "prerelease",
-      "prerelease": true,
-      "prerelease-type": "beta"
+      "versioning": "default"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remove `prerelease`, `prerelease-type`, and switch `versioning` from `prerelease` to `default` in release-please-config.json
- Once merged, release-please will close the current beta PR (#492) and open a new one for stable `2.15.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)